### PR TITLE
Phase 1-3: Add UI Components (NumberPad & AnswerField)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phase 1 MVP: Reusable UI components for math practice interface
   - `NumberPad` composable with 0-9 buttons in 2x5 grid layout
   - Child-friendly 64dp button size with Material 3 theming
+  - Accessibility support with content descriptions for screen readers (e.g., "Number 1", "Number 2")
   - `AnswerField` composable as read-only text field for displaying user input
   - Centered text with "?" placeholder and large typography for visibility
+  - Accessibility label "Your Answer" for screen reader users
   - Compose preview functions for both light and dark themes
+  - Instrumented UI tests (13 test cases) for both components covering rendering, interaction, and accessibility
 - Phase 1 MVP: Problem generator for creating math exercises
   - `ProblemGenerator` interface for generating math problems
   - `SimpleProblemGenerator` implementation with Metro DI integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Phase 1 MVP: Reusable UI components for math practice interface
+  - `NumberPad` composable with 0-9 buttons in 2x5 grid layout
+  - Child-friendly 64dp button size with Material 3 theming
+  - `AnswerField` composable as read-only text field for displaying user input
+  - Centered text with "?" placeholder and large typography for visibility
+  - Compose preview functions for both light and dark themes
 - Phase 1 MVP: Problem generator for creating math exercises
   - `ProblemGenerator` interface for generating math problems
   - `SimpleProblemGenerator` implementation with Metro DI integration

--- a/app/src/androidTest/java/dev/hossain/mathtutor/ui/component/AnswerFieldTest.kt
+++ b/app/src/androidTest/java/dev/hossain/mathtutor/ui/component/AnswerFieldTest.kt
@@ -1,0 +1,142 @@
+package dev.hossain.mathtutor.ui.component
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Instrumented tests for [AnswerField] component.
+ *
+ * These tests verify the rendering, accessibility, and behavior of the AnswerField component.
+ */
+class AnswerFieldTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun answerField_emptyAnswer_displaysPlaceholder() {
+        // Given
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = "")
+            }
+        }
+
+        // Then - placeholder "?" should be displayed
+        composeTestRule.onNodeWithText("?").assertIsDisplayed()
+    }
+
+    @Test
+    fun answerField_hasAccessibilityLabel() {
+        // Given
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = "")
+            }
+        }
+
+        // Then - label "Your Answer" should be present for screen readers
+        composeTestRule.onNodeWithText("Your Answer").assertIsDisplayed()
+    }
+
+    @Test
+    fun answerField_withAnswer_displaysAnswer() {
+        // Given
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = "42")
+            }
+        }
+
+        // Then - answer "42" should be displayed
+        composeTestRule.onNodeWithText("42").assertIsDisplayed()
+    }
+
+    @Test
+    fun answerField_withMultiDigitAnswer_displaysFullAnswer() {
+        // Given
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = "123")
+            }
+        }
+
+        // Then - full answer "123" should be displayed
+        composeTestRule.onNodeWithText("123").assertIsDisplayed()
+    }
+
+    @Test
+    fun answerField_updatingAnswer_displaysNewAnswer() {
+        // Given - initial answer
+        var answer = "1"
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = answer)
+            }
+        }
+
+        // Verify initial state
+        composeTestRule.onNodeWithText("1").assertIsDisplayed()
+
+        // When - updating answer
+        answer = "12"
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = answer)
+            }
+        }
+
+        // Then - new answer should be displayed
+        composeTestRule.onNodeWithText("12").assertIsDisplayed()
+    }
+
+    @Test
+    fun answerField_clearingAnswer_displaysPlaceholder() {
+        // Given - initial answer
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = "42")
+            }
+        }
+
+        // Verify initial state
+        composeTestRule.onNodeWithText("42").assertIsDisplayed()
+
+        // When - clearing answer
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = "")
+            }
+        }
+
+        // Then - placeholder should be displayed again
+        composeTestRule.onNodeWithText("?").assertIsDisplayed()
+    }
+
+    @Test
+    fun answerField_labelPersists_withAndWithoutAnswer() {
+        // Given - empty field
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = "")
+            }
+        }
+
+        // Then - label exists
+        composeTestRule.onNodeWithText("Your Answer").assertIsDisplayed()
+
+        // When - adding answer
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                AnswerField(answer = "42")
+            }
+        }
+
+        // Then - label still exists
+        composeTestRule.onNodeWithText("Your Answer").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/dev/hossain/mathtutor/ui/component/NumberPadTest.kt
+++ b/app/src/androidTest/java/dev/hossain/mathtutor/ui/component/NumberPadTest.kt
@@ -1,0 +1,129 @@
+package dev.hossain.mathtutor.ui.component
+
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Instrumented tests for [NumberPad] component.
+ *
+ * These tests verify the rendering, interaction, and accessibility of the NumberPad component.
+ */
+class NumberPadTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun numberPad_displaysAllNumbers() {
+        // Given
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                NumberPad(onNumberClick = {})
+            }
+        }
+
+        // Then - all numbers from 0-9 should be displayed
+        for (number in 0..9) {
+            composeTestRule.onNodeWithText(number.toString()).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun numberPad_allButtonsHaveAccessibilityLabels() {
+        // Given
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                NumberPad(onNumberClick = {})
+            }
+        }
+
+        // Then - all number buttons should have content descriptions
+        for (number in 0..9) {
+            composeTestRule
+                .onNodeWithContentDescription("Number $number")
+                .assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun numberPad_clickingNumber_invokesCallback() {
+        // Given
+        var clickedNumber: Int? = null
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                NumberPad(onNumberClick = { clickedNumber = it })
+            }
+        }
+
+        // When - clicking number 5
+        composeTestRule.onNodeWithContentDescription("Number 5").performClick()
+
+        // Then - callback should be invoked with 5
+        assertEquals(5, clickedNumber)
+    }
+
+    @Test
+    fun numberPad_clickingMultipleNumbers_invokesCallbackForEach() {
+        // Given
+        val clickedNumbers = mutableListOf<Int>()
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                NumberPad(onNumberClick = { clickedNumbers.add(it) })
+            }
+        }
+
+        // When - clicking numbers 1, 2, 3
+        composeTestRule.onNodeWithContentDescription("Number 1").performClick()
+        composeTestRule.onNodeWithContentDescription("Number 2").performClick()
+        composeTestRule.onNodeWithContentDescription("Number 3").performClick()
+
+        // Then - all three numbers should be recorded
+        assertEquals(listOf(1, 2, 3), clickedNumbers)
+    }
+
+    @Test
+    fun numberPad_clickingZero_invokesCallbackWithZero() {
+        // Given
+        var clickedNumber: Int? = null
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                NumberPad(onNumberClick = { clickedNumber = it })
+            }
+        }
+
+        // When - clicking number 0
+        composeTestRule.onNodeWithContentDescription("Number 0").performClick()
+
+        // Then - callback should be invoked with 0
+        assertEquals(0, clickedNumber)
+    }
+
+    @Test
+    fun numberPad_buttonsDisplayedInCorrectOrder() {
+        // Given
+        composeTestRule.setContent {
+            KidsMathTutorAppTheme {
+                NumberPad(onNumberClick = {})
+            }
+        }
+
+        // Then - verify all numbers are present (layout order verified visually)
+        // First row: 1, 2, 3, 4, 5
+        for (number in 1..5) {
+            composeTestRule.onNodeWithText(number.toString()).assertIsDisplayed()
+        }
+
+        // Second row: 6, 7, 8, 9, 0
+        for (number in 6..9) {
+            composeTestRule.onNodeWithText(number.toString()).assertIsDisplayed()
+        }
+        composeTestRule.onNodeWithText("0").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/ui/component/AnswerField.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/component/AnswerField.kt
@@ -1,0 +1,91 @@
+package dev.hossain.mathtutor.ui.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
+
+/**
+ * A read-only text field component for displaying the user's answer input.
+ *
+ * Displays the current answer with centered text and a placeholder "?" when empty.
+ * Uses Material 3 OutlinedTextField with large, child-friendly text.
+ *
+ * @param answer The current answer text to display (empty string if no input yet)
+ * @param modifier Optional modifier for the text field
+ */
+@Composable
+fun AnswerField(
+    answer: String,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = answer,
+        onValueChange = {}, // Read-only, no direct text input
+        modifier = modifier.fillMaxWidth(),
+        readOnly = true,
+        textStyle =
+            MaterialTheme.typography.displayLarge.copy(
+                textAlign = TextAlign.Center,
+            ),
+        placeholder = {
+            Text(
+                text = "?",
+                style = MaterialTheme.typography.displayLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+            )
+        },
+        colors =
+            OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = MaterialTheme.colorScheme.surface,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                disabledContainerColor = MaterialTheme.colorScheme.surface,
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+            ),
+        singleLine = true,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AnswerFieldEmptyPreview() {
+    KidsMathTutorAppTheme {
+        AnswerField(
+            answer = "",
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AnswerFieldWithAnswerPreview() {
+    KidsMathTutorAppTheme {
+        AnswerField(
+            answer = "42",
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AnswerFieldDarkPreview() {
+    KidsMathTutorAppTheme(darkTheme = true) {
+        AnswerField(
+            answer = "123",
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/ui/component/AnswerField.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/component/AnswerField.kt
@@ -32,6 +32,9 @@ fun AnswerField(
         onValueChange = {}, // Read-only, no direct text input
         modifier = modifier.fillMaxWidth(),
         readOnly = true,
+        label = {
+            Text("Your Answer")
+        },
         textStyle =
             MaterialTheme.typography.displayLarge.copy(
                 textAlign = TextAlign.Center,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/component/NumberPad.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/component/NumberPad.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
@@ -84,7 +86,10 @@ private fun NumberButton(
         onClick = onClick,
         modifier =
             modifier
-                .size(64.dp),
+                .size(64.dp)
+                .semantics {
+                    contentDescription = "Number $number"
+                },
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/component/NumberPad.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/component/NumberPad.kt
@@ -1,0 +1,121 @@
+package dev.hossain.mathtutor.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
+
+/**
+ * A number pad component for kids to input their answers.
+ *
+ * Displays numbers 0-9 in a 2x5 grid layout with large, child-friendly buttons.
+ * First row: 1, 2, 3, 4, 5
+ * Second row: 6, 7, 8, 9, 0
+ *
+ * @param onNumberClick Callback invoked when a number button is clicked, provides the number (0-9)
+ * @param modifier Optional modifier for the number pad container
+ */
+@Composable
+fun NumberPad(
+    onNumberClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // First row: 1, 2, 3, 4, 5
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            for (number in 1..5) {
+                NumberButton(
+                    number = number,
+                    onClick = { onNumberClick(number) },
+                )
+            }
+        }
+
+        // Second row: 6, 7, 8, 9, 0
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            for (number in 6..9) {
+                NumberButton(
+                    number = number,
+                    onClick = { onNumberClick(number) },
+                )
+            }
+            NumberButton(
+                number = 0,
+                onClick = { onNumberClick(0) },
+            )
+        }
+    }
+}
+
+/**
+ * A single number button with child-friendly size and styling.
+ *
+ * @param number The number to display (0-9)
+ * @param onClick Callback invoked when the button is clicked
+ * @param modifier Optional modifier for the button
+ */
+@Composable
+private fun NumberButton(
+    number: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier =
+            modifier
+                .size(64.dp),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+    ) {
+        Text(
+            text = number.toString(),
+            style = MaterialTheme.typography.headlineMedium,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NumberPadPreview() {
+    KidsMathTutorAppTheme {
+        NumberPad(
+            onNumberClick = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NumberPadDarkPreview() {
+    KidsMathTutorAppTheme(darkTheme = true) {
+        NumberPad(
+            onNumberClick = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}


### PR DESCRIPTION
## Overview
Implements Phase 1-3 (issue #9) - Reusable UI components for math practice interface.

## Changes
### UI Components
- **NumberPad**: Interactive number pad with 0-9 buttons
  - 2x5 grid layout (rows: 1-5, 6-9+0)
  - Child-friendly 64dp button size
  - Material 3 theming with primaryContainer colors
  - Click callback for number selection

- **AnswerField**: Read-only text field for displaying answers
  - Large centered text (displayLarge typography)
  - Placeholder "?" when empty
  - Material 3 OutlinedTextField styling
  - Optimized for kid visibility

### Features
- ✅ Compose preview functions for both components
- ✅ Light and dark theme previews included
- ✅ Fully Material 3 compliant
- ✅ No hardcoded colors - uses MaterialTheme.colorScheme
- ✅ Code formatted with ktlint
- ✅ No lint errors

## Testing
- All existing tests passing (41 tests)
- Components compile successfully
- Preview functions allow visual verification

## Related Issues
Closes #9

## Screenshots
Preview functions available in Android Studio for visual verification:
- `NumberPadPreview` / `NumberPadDarkPreview`
- `AnswerFieldEmptyPreview` / `AnswerFieldWithAnswerPreview` / `AnswerFieldDarkPreview`