### PR TITLE
fix: Convert DatabaseModule to interface with @ContributesTo

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/di/DatabaseModule.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/di/DatabaseModule.kt
@@ -1,40 +1,35 @@
 package dev.hossain.mathtutor.di
 
-import android.content.Context
 import androidx.room.Room
 import dev.hossain.mathtutor.data.local.MathDatabase
 import dev.hossain.mathtutor.data.local.dao.SessionDao
 import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 /**
  * Provides Room database and DAO for the application.
  * Uses Metro DI to provide database and DAO as singletons scoped to the application lifecycle.
+ *
+ * This interface uses [ContributesTo] which automatically contributes bindings to the [AppScope].
  */
-@SingleIn(AppScope::class)
-@Inject
-class DatabaseModule
-    constructor(
-        @ApplicationContext private val context: Context,
-    ) {
-        private val database: MathDatabase by lazy {
-            Room
-                .databaseBuilder(
-                    context,
-                    MathDatabase::class.java,
-                    MathDatabase.DATABASE_NAME,
-                ).fallbackToDestructiveMigration() // For Phase 2: OK to lose data during development
-                .build()
-        }
+@ContributesTo(AppScope::class)
+interface DatabaseModule {
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideMathDatabase(
+        @ApplicationContext context: android.content.Context,
+    ): MathDatabase =
+        Room
+            .databaseBuilder(
+                context,
+                MathDatabase::class.java,
+                MathDatabase.DATABASE_NAME,
+            ).fallbackToDestructiveMigration()
+            .build()
 
-        @Provides
-        @SingleIn(AppScope::class)
-        fun provideMathDatabase(): MathDatabase = database
-
-        @Provides
-        @SingleIn(AppScope::class)
-        fun provideSessionDao(): SessionDao = database.sessionDao()
-    }
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideSessionDao(database: MathDatabase): SessionDao = database.sessionDao()
+}


### PR DESCRIPTION
- Changed from class with @Inject to interface with @ContributesTo
- Follows Metro DI pattern for modules with @Provides methods
- Fixes Metro compiler error about duplicate metadata
- Matches CircuitProviders pattern for consistency

Fixes build failure in assembleDebug task.