### PR TITLE
fix: Use millisecond precision in ConvertersTest Instant round-trip test

### DIFF
--- a/app/src/test/java/dev/hossain/mathtutor/data/local/ConvertersTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/data/local/ConvertersTest.kt
@@ -91,7 +91,9 @@ class ConvertersTest {
 
     @Test
     fun `round trip conversion preserves Instant`() {
-        val original = Instant.now()
+        // Use ofEpochMilli to create an Instant with only millisecond precision
+        // to match the precision preserved by the converters
+        val original = Instant.ofEpochMilli(Instant.now().toEpochMilli())
         val converted = converters.toInstant(converters.fromInstant(original))
         assertEquals(original, converted)
     }


### PR DESCRIPTION
The converter stores Instant as epoch milliseconds (Long), which only preserves millisecond precision. The test was using Instant.now() which includes nanosecond precision, causing the round-trip assertion to fail.

Changed to use Instant.ofEpochMilli() to create an Instant with only millisecond precision, matching what the converter preserves.

Fixes the last remaining test failure in the build.