### PR TITLE
fix: Fix DataStore singleton crash after onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ google-services.json
 # Android Profiling
 *.hprof
 .DS_Store
+*.salive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed crash after onboarding due to multiple DataStore instances. Created singleton DataStore in `UserPreferencesDataStore.kt` shared by both `UserPreferencesRepository` and `UserProfileRepository`.
+
 ### Added
 - **Phase 4-6: Personalization Integration & Polish** - Integrated personalized elements throughout the app
   - Updated `HomeScreen` with personalization:

--- a/app/src/main/java/dev/hossain/mathtutor/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/UserPreferencesRepository.kt
@@ -1,11 +1,9 @@
 package dev.hossain.mathtutor.data
 
 import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.preferencesDataStore
+import dev.hossain.mathtutor.data.local.userPreferencesDataStore
 import dev.hossain.mathtutor.di.ApplicationContext
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -13,8 +11,6 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "user_preferences")
 
 interface UserPreferencesRepository {
     val isOnboardingCompleted: Flow<Boolean>
@@ -34,12 +30,12 @@ class UserPreferencesRepositoryImpl
         }
 
         override val isOnboardingCompleted: Flow<Boolean> =
-            context.dataStore.data.map { preferences ->
+            context.userPreferencesDataStore.data.map { preferences ->
                 preferences[PreferencesKeys.ONBOARDING_COMPLETED] ?: false
             }
 
         override suspend fun setOnboardingCompleted(completed: Boolean) {
-            context.dataStore.edit { preferences ->
+            context.userPreferencesDataStore.edit { preferences ->
                 preferences[PreferencesKeys.ONBOARDING_COMPLETED] = completed
             }
         }

--- a/app/src/main/java/dev/hossain/mathtutor/data/local/UserPreferencesDataStore.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/local/UserPreferencesDataStore.kt
@@ -1,0 +1,12 @@
+package dev.hossain.mathtutor.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+/**
+ * Singleton DataStore for user preferences.
+ * Shared by UserPreferencesRepository and UserProfileRepository.
+ */
+val Context.userPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(name = "user_preferences")

--- a/app/src/main/java/dev/hossain/mathtutor/data/repository/UserProfileRepositoryImpl.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/repository/UserProfileRepositoryImpl.kt
@@ -1,13 +1,11 @@
 package dev.hossain.mathtutor.data.repository
 
 import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
+import dev.hossain.mathtutor.data.local.userPreferencesDataStore
 import dev.hossain.mathtutor.di.ApplicationContext
 import dev.hossain.mathtutor.domain.model.GradeLevel
 import dev.hossain.mathtutor.domain.model.UserProfile
@@ -19,9 +17,6 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.time.Instant
-
-// Shared DataStore for user preferences (also used by UserPreferencesRepository)
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "user_preferences")
 
 /**
  * Implementation of [UserProfileRepository] using DataStore Preferences.
@@ -42,7 +37,7 @@ class UserProfileRepositoryImpl
         }
 
         override fun getProfile(): Flow<UserProfile?> =
-            context.dataStore.data.map { preferences ->
+            context.userPreferencesDataStore.data.map { preferences ->
                 val gradeString = preferences[PreferencesKeys.GRADE_KEY]
                 val createdAtMillis = preferences[PreferencesKeys.CREATED_AT_KEY]
 
@@ -65,7 +60,7 @@ class UserProfileRepositoryImpl
             }
 
         override suspend fun saveProfile(profile: UserProfile) {
-            context.dataStore.edit { preferences ->
+            context.userPreferencesDataStore.edit { preferences ->
                 preferences[PreferencesKeys.NAME_KEY] =
                     profile.name
                         ?: "" // Store empty string instead of null
@@ -76,19 +71,19 @@ class UserProfileRepositoryImpl
         }
 
         override suspend fun updateGradeLevel(gradeLevel: GradeLevel) {
-            context.dataStore.edit { preferences ->
+            context.userPreferencesDataStore.edit { preferences ->
                 preferences[PreferencesKeys.GRADE_KEY] = gradeLevel.name
             }
         }
 
         override suspend fun updateName(name: String?) {
-            context.dataStore.edit { preferences ->
+            context.userPreferencesDataStore.edit { preferences ->
                 preferences[PreferencesKeys.NAME_KEY] = name ?: ""
             }
         }
 
         override suspend fun updateAdaptiveDifficulty(enabled: Boolean) {
-            context.dataStore.edit { preferences ->
+            context.userPreferencesDataStore.edit { preferences ->
                 preferences[PreferencesKeys.ADAPTIVE_KEY] = enabled
             }
         }


### PR DESCRIPTION
- Created singleton UserPreferencesDataStore shared by both repositories
- Fixes IllegalStateException: multiple DataStores active for same file
- Both UserPreferencesRepository and UserProfileRepository now use userPreferencesDataStore
- Updated CHANGELOG.md with fix