### PR TITLE
feat(phase-6): Add game data layer for mini-games (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Phase 6-1: Game Data Layer & Repository** - Foundation for mini-games feature
+  - **Domain Models**:
+    - `Game` enum with MATH_RACE, MEMORY_MATCH, NUMBER_SEQUENCE including unlock requirements (50, 100, 200 problems)
+    - `GameSession` data class with score, accuracy calculation, and star rating
+    - `GameStats` data class for aggregated game statistics (personal best, total plays, averages)
+  - **Database Layer**:
+    - `GameSessionEntity` Room entity with indexed gameId column
+    - `GameSessionDao` with comprehensive queries (personal best, stats aggregation, recent sessions)
+    - Room database migration v4 → v5 for game_sessions table
+    - MathDatabase updated to version 5 with GameSessionEntity
+  - **Repository Layer**:
+    - `GameRepository` interface with Flow-based reactive data access
+    - `GameRepositoryImpl` with Metro DI integration (@ContributesBinding)
+    - Integration with SessionRepository for game unlock checks via `getOverallStats().totalProblems`
+  - **DI Integration**:
+    - DatabaseModule updated with MIGRATION_4_5 and GameSessionDao provider
+  - **Unit Tests**:
+    - `GameTest` - 15 tests covering unlock logic, progress calculation
+    - `GameSessionTest` - 12 tests covering accuracy, star ratings, computed properties
+    - `GameStatsTest` - 9 tests covering aggregation and star ratings
+    - `GameRepositoryImplTest` - 15 tests with FakeGameSessionDao and FakeSessionRepository
+
 ## [1.4.0] - 2025-12-19
 
 ### Added

--- a/app/schemas/dev.hossain.mathtutor.data.local.MathDatabase/5.json
+++ b/app/schemas/dev.hossain.mathtutor.data.local.MathDatabase/5.json
@@ -1,0 +1,315 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "bec7c1f19e4e45c149c9d335131e96b6",
+    "entities": [
+      {
+        "tableName": "practice_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation` TEXT NOT NULL, `totalProblems` INTEGER NOT NULL, `correctAnswers` INTEGER NOT NULL, `incorrectAnswers` INTEGER NOT NULL, `accuracy` REAL NOT NULL, `durationSeconds` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `gradeLevel` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operation",
+            "columnName": "operation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalProblems",
+            "columnName": "totalProblems",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctAnswers",
+            "columnName": "correctAnswers",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "incorrectAnswers",
+            "columnName": "incorrectAnswers",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accuracy",
+            "columnName": "accuracy",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gradeLevel",
+            "columnName": "gradeLevel",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "badges",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `icon` TEXT NOT NULL, `category` TEXT NOT NULL, `requirementType` TEXT NOT NULL, `requirementData` TEXT NOT NULL, `unlockedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requirementType",
+            "columnName": "requirementType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requirementData",
+            "columnName": "requirementData",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unlockedAt",
+            "columnName": "unlockedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "streak",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `currentStreak` INTEGER NOT NULL, `longestStreak` INTEGER NOT NULL, `lastPracticeDate` INTEGER, `totalDaysPracticed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreak",
+            "columnName": "currentStreak",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreak",
+            "columnName": "longestStreak",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPracticeDate",
+            "columnName": "lastPracticeDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalDaysPracticed",
+            "columnName": "totalDaysPracticed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "performance_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation` TEXT NOT NULL, `gradeLevel` TEXT NOT NULL, `problemId` TEXT NOT NULL, `isCorrect` INTEGER NOT NULL, `attemptCount` INTEGER NOT NULL, `timeSpentSeconds` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operation",
+            "columnName": "operation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gradeLevel",
+            "columnName": "gradeLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "problemId",
+            "columnName": "problemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCorrect",
+            "columnName": "isCorrect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSpentSeconds",
+            "columnName": "timeSpentSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "game_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `gameId` TEXT NOT NULL, `startTime` INTEGER NOT NULL, `endTime` INTEGER NOT NULL, `score` INTEGER NOT NULL, `correctAnswers` INTEGER NOT NULL, `totalAttempts` INTEGER NOT NULL, `durationSeconds` INTEGER NOT NULL, `gradeLevel` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctAnswers",
+            "columnName": "correctAnswers",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAttempts",
+            "columnName": "totalAttempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gradeLevel",
+            "columnName": "gradeLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_game_sessions_gameId",
+            "unique": false,
+            "columnNames": [
+              "gameId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_game_sessions_gameId` ON `${TABLE_NAME}` (`gameId`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bec7c1f19e4e45c149c9d335131e96b6')"
+    ]
+  }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/data/local/MathDatabase.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/local/MathDatabase.kt
@@ -6,26 +6,30 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import dev.hossain.mathtutor.data.local.dao.BadgeDao
+import dev.hossain.mathtutor.data.local.dao.GameSessionDao
 import dev.hossain.mathtutor.data.local.dao.PerformanceDao
 import dev.hossain.mathtutor.data.local.dao.SessionDao
 import dev.hossain.mathtutor.data.local.dao.StreakDao
 import dev.hossain.mathtutor.data.local.entity.BadgeEntity
+import dev.hossain.mathtutor.data.local.entity.GameSessionEntity
 import dev.hossain.mathtutor.data.local.entity.PerformanceEntity
 import dev.hossain.mathtutor.data.local.entity.PracticeSessionEntity
 import dev.hossain.mathtutor.data.local.entity.StreakEntity
 
 /**
  * Room database for Kids Math Tutor app.
- * Stores practice session history, statistics, badge achievements, daily streaks, and performance records.
+ * Stores practice session history, statistics, badge achievements, daily streaks,
+ * performance records, and game session data.
  *
  * Database name: kids_math_tutor.db
- * Version: 4 (added performance tracking system for adaptive difficulty)
+ * Version: 5 (added game sessions for mini-games)
  *
  * Entities:
  * - [PracticeSessionEntity]: Completed practice sessions with statistics
  * - [BadgeEntity]: Badge achievements and unlock status
  * - [StreakEntity]: Daily practice streak tracking
  * - [PerformanceEntity]: Individual problem performance records for adaptive difficulty
+ * - [GameSessionEntity]: Mini-game session data and scores
  *
  * Type Converters:
  * - [Converters]: Handles MathOperation, BadgeCategory, GradeLevel enums, Instant timestamp, and LocalDate conversions
@@ -36,8 +40,9 @@ import dev.hossain.mathtutor.data.local.entity.StreakEntity
         BadgeEntity::class,
         StreakEntity::class,
         PerformanceEntity::class,
+        GameSessionEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -69,6 +74,13 @@ abstract class MathDatabase : RoomDatabase() {
      * @return PerformanceDao instance
      */
     abstract fun performanceDao(): PerformanceDao
+
+    /**
+     * Provides access to game session data operations.
+     *
+     * @return GameSessionDao instance
+     */
+    abstract fun gameSessionDao(): GameSessionDao
 
     companion object {
         /**
@@ -143,6 +155,38 @@ abstract class MathDatabase : RoomDatabase() {
                             timeSpentSeconds INTEGER NOT NULL,
                             timestamp INTEGER NOT NULL
                         )
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+        /**
+         * Migration from database version 4 to version 5.
+         * Adds the game_sessions table for mini-game tracking (Math Race, etc.).
+         */
+        val MIGRATION_4_5 =
+            object : Migration(4, 5) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    // Create game_sessions table
+                    db.execSQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS game_sessions (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                            gameId TEXT NOT NULL,
+                            startTime INTEGER NOT NULL,
+                            endTime INTEGER NOT NULL,
+                            score INTEGER NOT NULL,
+                            correctAnswers INTEGER NOT NULL,
+                            totalAttempts INTEGER NOT NULL,
+                            durationSeconds INTEGER NOT NULL,
+                            gradeLevel TEXT NOT NULL
+                        )
+                        """.trimIndent(),
+                    )
+                    // Create index on gameId for faster lookups
+                    db.execSQL(
+                        """
+                        CREATE INDEX IF NOT EXISTS index_game_sessions_gameId ON game_sessions (gameId)
                         """.trimIndent(),
                     )
                 }

--- a/app/src/main/java/dev/hossain/mathtutor/data/local/dao/GameSessionDao.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/local/dao/GameSessionDao.kt
@@ -1,0 +1,165 @@
+package dev.hossain.mathtutor.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import dev.hossain.mathtutor.data.local.entity.GameSessionEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Data Access Object for game session database operations.
+ * Provides methods to insert, query, and aggregate game session data.
+ * All query methods return Flow for reactive updates.
+ */
+@Dao
+interface GameSessionDao {
+    /**
+     * Inserts a new game session into the database.
+     *
+     * @param session The game session to insert
+     * @return The ID of the inserted session
+     */
+    @Insert
+    suspend fun insertSession(session: GameSessionEntity): Long
+
+    /**
+     * Retrieves all game sessions ordered by most recent first.
+     *
+     * @return Flow of all game sessions
+     */
+    @Query("SELECT * FROM game_sessions ORDER BY endTime DESC")
+    fun getAllSessions(): Flow<List<GameSessionEntity>>
+
+    /**
+     * Retrieves all sessions for a specific game type ordered by most recent first.
+     *
+     * @param gameId The game identifier (e.g., "MATH_RACE")
+     * @return Flow of sessions for the specified game
+     */
+    @Query("SELECT * FROM game_sessions WHERE gameId = :gameId ORDER BY endTime DESC")
+    fun getSessionsByGame(gameId: String): Flow<List<GameSessionEntity>>
+
+    /**
+     * Retrieves the most recent N game sessions.
+     *
+     * @param limit Maximum number of sessions to retrieve
+     * @return Flow of recent sessions
+     */
+    @Query("SELECT * FROM game_sessions ORDER BY endTime DESC LIMIT :limit")
+    fun getRecentSessions(limit: Int = 10): Flow<List<GameSessionEntity>>
+
+    /**
+     * Retrieves the personal best (highest score) for a specific game.
+     *
+     * @param gameId The game identifier
+     * @return Flow of the highest score, or null if no sessions exist
+     */
+    @Query("SELECT MAX(score) FROM game_sessions WHERE gameId = :gameId")
+    fun getPersonalBest(gameId: String): Flow<Int?>
+
+    /**
+     * Retrieves the session with the personal best score for a specific game.
+     *
+     * @param gameId The game identifier
+     * @return Flow of the best session, or null if no sessions exist
+     */
+    @Query("SELECT * FROM game_sessions WHERE gameId = :gameId ORDER BY score DESC LIMIT 1")
+    fun getBestSession(gameId: String): Flow<GameSessionEntity?>
+
+    /**
+     * Counts the total number of times a specific game has been played.
+     *
+     * @param gameId The game identifier
+     * @return Flow of the play count
+     */
+    @Query("SELECT COUNT(*) FROM game_sessions WHERE gameId = :gameId")
+    fun getTotalGamesPlayed(gameId: String): Flow<Int>
+
+    /**
+     * Calculates the average score for a specific game.
+     *
+     * @param gameId The game identifier
+     * @return Flow of the average score, or null if no sessions exist
+     */
+    @Query("SELECT AVG(CAST(score AS REAL)) FROM game_sessions WHERE gameId = :gameId")
+    fun getAverageScore(gameId: String): Flow<Float?>
+
+    /**
+     * Retrieves the best accuracy percentage achieved for a specific game.
+     *
+     * @param gameId The game identifier
+     * @return Flow of the best accuracy (0-100), or null if no sessions exist
+     */
+    @Query(
+        """
+        SELECT MAX(CAST(correctAnswers AS REAL) / totalAttempts * 100) 
+        FROM game_sessions 
+        WHERE gameId = :gameId AND totalAttempts > 0
+        """,
+    )
+    fun getBestAccuracy(gameId: String): Flow<Float?>
+
+    /**
+     * Retrieves the timestamp of the most recent session for a specific game.
+     *
+     * @param gameId The game identifier
+     * @return Flow of the most recent end time, or null if no sessions exist
+     */
+    @Query("SELECT MAX(endTime) FROM game_sessions WHERE gameId = :gameId")
+    fun getLastPlayedTimestamp(gameId: String): Flow<Long?>
+
+    /**
+     * Calculates the total correct answers for a specific game.
+     *
+     * @param gameId The game identifier
+     * @return Flow of total correct answers, or null if no sessions exist
+     */
+    @Query("SELECT SUM(correctAnswers) FROM game_sessions WHERE gameId = :gameId")
+    fun getTotalCorrectAnswers(gameId: String): Flow<Int?>
+
+    /**
+     * Calculates the total attempts for a specific game.
+     *
+     * @param gameId The game identifier
+     * @return Flow of total attempts, or null if no sessions exist
+     */
+    @Query("SELECT SUM(totalAttempts) FROM game_sessions WHERE gameId = :gameId")
+    fun getTotalAttempts(gameId: String): Flow<Int?>
+
+    /**
+     * Counts the total number of game sessions across all games.
+     *
+     * @return Flow of total session count
+     */
+    @Query("SELECT COUNT(*) FROM game_sessions")
+    fun getTotalSessionCount(): Flow<Int>
+
+    /**
+     * Counts the number of perfect games (100% accuracy) for a specific game.
+     *
+     * @param gameId The game identifier
+     * @return Flow of perfect game count
+     */
+    @Query(
+        """
+        SELECT COUNT(*) FROM game_sessions 
+        WHERE gameId = :gameId AND correctAnswers = totalAttempts AND totalAttempts > 0
+        """,
+    )
+    fun getPerfectGameCount(gameId: String): Flow<Int>
+
+    /**
+     * Deletes all game sessions from the database.
+     * Useful for testing or user-requested data reset.
+     */
+    @Query("DELETE FROM game_sessions")
+    suspend fun deleteAllSessions()
+
+    /**
+     * Deletes all sessions for a specific game.
+     *
+     * @param gameId The game identifier
+     */
+    @Query("DELETE FROM game_sessions WHERE gameId = :gameId")
+    suspend fun deleteSessionsByGame(gameId: String)
+}

--- a/app/src/main/java/dev/hossain/mathtutor/data/local/entity/GameSessionEntity.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/local/entity/GameSessionEntity.kt
@@ -1,0 +1,85 @@
+package dev.hossain.mathtutor.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import dev.hossain.mathtutor.domain.model.Game
+import dev.hossain.mathtutor.domain.model.GradeLevel
+import java.time.Instant
+
+/**
+ * Room entity representing a completed game session.
+ * Stores all statistics and metadata from a single game play for persistence.
+ *
+ * The gameId column is indexed to optimize queries that filter by game type,
+ * such as getting personal best or stats for a specific game.
+ *
+ * @property id Unique identifier for this game session (auto-generated)
+ * @property gameId The game type identifier (Game enum name, e.g., "MATH_RACE")
+ * @property startTime When the game session started (stored as epoch milliseconds)
+ * @property endTime When the game session ended (stored as epoch milliseconds)
+ * @property score Number of correct answers (points earned) in this session
+ * @property correctAnswers Number of problems answered correctly
+ * @property totalAttempts Total number of problems attempted (correct + incorrect)
+ * @property durationSeconds Actual duration of the game session in seconds
+ * @property gradeLevel The grade level at which the game was played (GradeLevel enum name)
+ */
+@Entity(
+    tableName = "game_sessions",
+    indices = [
+        Index(value = ["gameId"]),
+    ],
+)
+data class GameSessionEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val gameId: String,
+    val startTime: Instant,
+    val endTime: Instant,
+    val score: Int,
+    val correctAnswers: Int,
+    val totalAttempts: Int,
+    val durationSeconds: Int,
+    val gradeLevel: GradeLevel,
+) {
+    /**
+     * Converts this entity to a domain model.
+     *
+     * @param isNewRecord Whether this session achieved a new personal best
+     * @return GameSession domain model
+     */
+    fun toDomainModel(isNewRecord: Boolean = false): dev.hossain.mathtutor.domain.model.GameSession =
+        dev.hossain.mathtutor.domain.model.GameSession(
+            id = id,
+            game = Game.valueOf(gameId),
+            startTime = startTime,
+            endTime = endTime,
+            score = score,
+            correctAnswers = correctAnswers,
+            totalAttempts = totalAttempts,
+            durationSeconds = durationSeconds,
+            gradeLevel = gradeLevel,
+            isNewRecord = isNewRecord,
+        )
+
+    companion object {
+        /**
+         * Creates an entity from a domain model.
+         *
+         * @param session The domain model to convert
+         * @return GameSessionEntity for database storage
+         */
+        fun fromDomainModel(session: dev.hossain.mathtutor.domain.model.GameSession): GameSessionEntity =
+            GameSessionEntity(
+                id = session.id,
+                gameId = session.game.name,
+                startTime = session.startTime,
+                endTime = session.endTime,
+                score = session.score,
+                correctAnswers = session.correctAnswers,
+                totalAttempts = session.totalAttempts,
+                durationSeconds = session.durationSeconds,
+                gradeLevel = session.gradeLevel,
+            )
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/data/repository/GameRepositoryImpl.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/repository/GameRepositoryImpl.kt
@@ -1,0 +1,131 @@
+package dev.hossain.mathtutor.data.repository
+
+import dev.hossain.mathtutor.data.local.dao.GameSessionDao
+import dev.hossain.mathtutor.data.local.entity.GameSessionEntity
+import dev.hossain.mathtutor.domain.model.Game
+import dev.hossain.mathtutor.domain.model.GameSession
+import dev.hossain.mathtutor.domain.model.GameStats
+import dev.hossain.mathtutor.domain.repository.GameRepository
+import dev.hossain.mathtutor.domain.repository.SessionRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import java.time.Instant
+
+/**
+ * Internal data class to hold detailed game statistics during combine operations.
+ */
+private data class GameStatsDetails(
+    val bestAccuracy: Float,
+    val lastPlayedAt: Instant?,
+    val totalCorrectAnswers: Int,
+    val totalAttempts: Int,
+)
+
+/**
+ * Implementation of [GameRepository] using Room database.
+ * Handles all game session data operations with Flow-based reactive streams.
+ *
+ * Uses [SessionRepository] to access total problems solved for game unlock checks.
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+@Inject
+class GameRepositoryImpl
+    constructor(
+        private val gameSessionDao: GameSessionDao,
+        private val sessionRepository: SessionRepository,
+    ) : GameRepository {
+        override suspend fun saveGameSession(session: GameSession): Long {
+            val entity = GameSessionEntity.fromDomainModel(session)
+            return gameSessionDao.insertSession(entity)
+        }
+
+        override fun getPersonalBest(game: Game): Flow<Int> = gameSessionDao.getPersonalBest(game.name).map { it ?: 0 }
+
+        override fun getBestSession(game: Game): Flow<GameSession?> =
+            gameSessionDao.getBestSession(game.name).map { entity ->
+                entity?.toDomainModel(isNewRecord = true)
+            }
+
+        override fun getGameStats(game: Game): Flow<GameStats> {
+            // Combine the first group of flows (personal best, total games, average score)
+            val basicStatsFlow =
+                combine(
+                    gameSessionDao.getPersonalBest(game.name),
+                    gameSessionDao.getTotalGamesPlayed(game.name),
+                    gameSessionDao.getAverageScore(game.name),
+                ) { personalBest, totalGamesPlayed, averageScore ->
+                    Triple(personalBest ?: 0, totalGamesPlayed, averageScore ?: 0f)
+                }
+
+            // Combine the second group of flows (accuracy, last played, correct answers, attempts)
+            val detailedStatsFlow =
+                combine(
+                    gameSessionDao.getBestAccuracy(game.name),
+                    gameSessionDao.getLastPlayedTimestamp(game.name),
+                    gameSessionDao.getTotalCorrectAnswers(game.name),
+                    gameSessionDao.getTotalAttempts(game.name),
+                ) { bestAccuracy, lastPlayed, totalCorrect, totalAttempts ->
+                    GameStatsDetails(
+                        bestAccuracy = bestAccuracy ?: 0f,
+                        lastPlayedAt = lastPlayed?.let { Instant.ofEpochMilli(it) },
+                        totalCorrectAnswers = totalCorrect ?: 0,
+                        totalAttempts = totalAttempts ?: 0,
+                    )
+                }
+
+            // Combine both groups into final GameStats
+            return combine(basicStatsFlow, detailedStatsFlow) { basic, detailed ->
+                GameStats(
+                    game = game,
+                    personalBest = basic.first,
+                    totalGamesPlayed = basic.second,
+                    averageScore = basic.third,
+                    bestAccuracy = detailed.bestAccuracy,
+                    lastPlayedAt = detailed.lastPlayedAt,
+                    totalCorrectAnswers = detailed.totalCorrectAnswers,
+                    totalAttempts = detailed.totalAttempts,
+                )
+            }
+        }
+
+        override fun getTotalGamesPlayed(game: Game): Flow<Int> = gameSessionDao.getTotalGamesPlayed(game.name)
+
+        override fun isGameUnlocked(game: Game): Flow<Boolean> =
+            sessionRepository.getOverallStats().map { stats ->
+                game.isUnlocked(stats.totalProblems)
+            }
+
+        override fun getSessionsByGame(game: Game): Flow<List<GameSession>> =
+            gameSessionDao.getSessionsByGame(game.name).map { entities ->
+                entities.map { it.toDomainModel() }
+            }
+
+        override fun getRecentSessions(limit: Int): Flow<List<GameSession>> =
+            gameSessionDao.getRecentSessions(limit).map { entities ->
+                entities.map { it.toDomainModel() }
+            }
+
+        override fun getAllGameStats(): Flow<Map<Game, GameStats>> {
+            // Combine stats for all games
+            val statsFlows =
+                Game.entries.map { game ->
+                    getGameStats(game).map { stats -> game to stats }
+                }
+
+            return combine(statsFlows) { statsArray ->
+                statsArray.toMap()
+            }
+        }
+
+        override fun getPerfectGameCount(game: Game): Flow<Int> = gameSessionDao.getPerfectGameCount(game.name)
+
+        override suspend fun clearAllSessions() {
+            gameSessionDao.deleteAllSessions()
+        }
+    }

--- a/app/src/main/java/dev/hossain/mathtutor/di/DatabaseModule.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package dev.hossain.mathtutor.di
 import androidx.room.Room
 import dev.hossain.mathtutor.data.local.MathDatabase
 import dev.hossain.mathtutor.data.local.dao.BadgeDao
+import dev.hossain.mathtutor.data.local.dao.GameSessionDao
 import dev.hossain.mathtutor.data.local.dao.PerformanceDao
 import dev.hossain.mathtutor.data.local.dao.SessionDao
 import dev.hossain.mathtutor.data.local.dao.StreakDao
@@ -33,6 +34,7 @@ interface DatabaseModule {
                 MathDatabase.MIGRATION_1_2,
                 MathDatabase.MIGRATION_2_3,
                 MathDatabase.MIGRATION_3_4,
+                MathDatabase.MIGRATION_4_5,
             ).fallbackToDestructiveMigration(dropAllTables = true)
             .build()
 
@@ -51,4 +53,8 @@ interface DatabaseModule {
     @Provides
     @SingleIn(AppScope::class)
     fun providePerformanceDao(database: MathDatabase): PerformanceDao = database.performanceDao()
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideGameSessionDao(database: MathDatabase): GameSessionDao = database.gameSessionDao()
 }

--- a/app/src/main/java/dev/hossain/mathtutor/domain/model/Game.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/domain/model/Game.kt
@@ -1,0 +1,80 @@
+package dev.hossain.mathtutor.domain.model
+
+/**
+ * Represents the available mini-games in the Kids Math Tutor app.
+ * Each game has specific requirements to unlock and provides a unique way to practice math.
+ *
+ * @property displayName The human-readable name of the game shown in the UI
+ * @property description Brief description of what the game involves
+ * @property icon Emoji icon representing the game
+ * @property unlockRequirement Number of total problems that must be solved to unlock this game
+ * @property durationSeconds Duration of the game in seconds (e.g., 60 for Math Race)
+ */
+enum class Game(
+    val displayName: String,
+    val description: String,
+    val icon: String,
+    val unlockRequirement: Int,
+    val durationSeconds: Int,
+) {
+    /**
+     * Math Race: Solve as many problems as possible in 60 seconds.
+     * First game to unlock - designed to be accessible early in the user's journey.
+     */
+    MATH_RACE(
+        displayName = "Math Race",
+        description = "Solve as many problems as you can in 60 seconds!",
+        icon = "⏱️",
+        unlockRequirement = 50,
+        durationSeconds = 60,
+    ),
+
+    /**
+     * Memory Match: Match math problems with their answers.
+     * Second game to unlock - requires more practice before access.
+     */
+    MEMORY_MATCH(
+        displayName = "Memory Match",
+        description = "Match problems with answers!",
+        icon = "🧩",
+        unlockRequirement = 100,
+        durationSeconds = 120,
+    ),
+
+    /**
+     * Number Sequence: Find the missing number in a sequence.
+     * Third game to unlock - rewards dedicated practice.
+     */
+    NUMBER_SEQUENCE(
+        displayName = "Number Sequence",
+        description = "Find the missing number!",
+        icon = "🎲",
+        unlockRequirement = 200,
+        durationSeconds = 90,
+    ),
+    ;
+
+    /**
+     * Checks if the game is unlocked based on the total number of problems solved.
+     *
+     * @param totalProblemsSolved The total number of problems the user has solved
+     * @return true if the game is unlocked, false otherwise
+     */
+    fun isUnlocked(totalProblemsSolved: Int): Boolean = totalProblemsSolved >= unlockRequirement
+
+    /**
+     * Calculates the progress towards unlocking this game.
+     *
+     * @param totalProblemsSolved The total number of problems the user has solved
+     * @return Progress as a float between 0.0 (no progress) and 1.0 (unlocked)
+     */
+    fun unlockProgress(totalProblemsSolved: Int): Float = (totalProblemsSolved.toFloat() / unlockRequirement).coerceIn(0f, 1f)
+
+    /**
+     * Returns the number of problems remaining to unlock this game.
+     *
+     * @param totalProblemsSolved The total number of problems the user has solved
+     * @return Number of problems still needed, or 0 if already unlocked
+     */
+    fun problemsUntilUnlock(totalProblemsSolved: Int): Int = (unlockRequirement - totalProblemsSolved).coerceAtLeast(0)
+}

--- a/app/src/main/java/dev/hossain/mathtutor/domain/model/GameSession.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/domain/model/GameSession.kt
@@ -1,0 +1,118 @@
+package dev.hossain.mathtutor.domain.model
+
+import java.time.Instant
+
+/**
+ * Domain model representing a completed game session.
+ * Captures all the statistics and metadata from a single game play.
+ *
+ * @property id Unique identifier for this game session (0 for new sessions)
+ * @property game The type of game that was played
+ * @property startTime When the game session started
+ * @property endTime When the game session ended
+ * @property score Number of correct answers (points earned)
+ * @property correctAnswers Number of problems answered correctly
+ * @property totalAttempts Total number of problems attempted (correct + incorrect)
+ * @property durationSeconds Actual duration of the game session in seconds
+ * @property gradeLevel The grade level at which the game was played
+ * @property isNewRecord Whether this session achieved a new personal best
+ */
+data class GameSession(
+    val id: Long = 0,
+    val game: Game,
+    val startTime: Instant,
+    val endTime: Instant,
+    val score: Int,
+    val correctAnswers: Int,
+    val totalAttempts: Int,
+    val durationSeconds: Int,
+    val gradeLevel: GradeLevel,
+    val isNewRecord: Boolean = false,
+) {
+    /**
+     * Calculates the accuracy percentage for this game session.
+     *
+     * @return Accuracy as a percentage (0.0 - 100.0), or 0.0 if no attempts
+     */
+    val accuracy: Float
+        get() =
+            if (totalAttempts > 0) {
+                (correctAnswers.toFloat() / totalAttempts) * 100f
+            } else {
+                0f
+            }
+
+    /**
+     * Calculates the average time spent per problem.
+     *
+     * @return Average seconds per problem, or 0.0 if no attempts
+     */
+    val averageTimePerProblem: Float
+        get() =
+            if (totalAttempts > 0) {
+                durationSeconds.toFloat() / totalAttempts
+            } else {
+                0f
+            }
+
+    /**
+     * Calculates the problems solved per minute rate.
+     *
+     * @return Problems per minute, or 0.0 if duration is 0
+     */
+    val problemsPerMinute: Float
+        get() =
+            if (durationSeconds > 0) {
+                (totalAttempts.toFloat() / durationSeconds) * 60f
+            } else {
+                0f
+            }
+
+    /**
+     * Checks if the player achieved a perfect game (100% accuracy).
+     *
+     * @return true if all attempts were correct, false otherwise
+     */
+    val isPerfectGame: Boolean
+        get() = totalAttempts > 0 && correctAnswers == totalAttempts
+
+    /**
+     * Returns a star rating (1-5) based on accuracy.
+     * Uses the same scale as SessionStats for consistency.
+     *
+     * @return Number of stars (1-5)
+     */
+    fun getStarRating(): Int =
+        when {
+            accuracy >= 90f -> 5
+            accuracy >= 80f -> 4
+            accuracy >= 70f -> 3
+            accuracy >= 60f -> 2
+            else -> 1
+        }
+
+    companion object {
+        /**
+         * Creates a new GameSession with the current time as start time.
+         * Useful for starting a new game.
+         *
+         * @param game The type of game to play
+         * @param gradeLevel The grade level to use for problem generation
+         * @return A new GameSession with default values and current start time
+         */
+        fun startNew(
+            game: Game,
+            gradeLevel: GradeLevel,
+        ): GameSession =
+            GameSession(
+                game = game,
+                startTime = Instant.now(),
+                endTime = Instant.now(),
+                score = 0,
+                correctAnswers = 0,
+                totalAttempts = 0,
+                durationSeconds = 0,
+                gradeLevel = gradeLevel,
+            )
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/domain/model/GameStats.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/domain/model/GameStats.kt
@@ -1,0 +1,83 @@
+package dev.hossain.mathtutor.domain.model
+
+import java.time.Instant
+
+/**
+ * Aggregated statistics for a specific game type.
+ * Provides an overview of the user's performance and progress for a particular game.
+ *
+ * @property game The game type these statistics are for
+ * @property personalBest The highest score ever achieved in this game
+ * @property totalGamesPlayed Total number of times this game has been played
+ * @property averageScore Average score across all game sessions
+ * @property bestAccuracy Highest accuracy percentage achieved
+ * @property lastPlayedAt Timestamp of when this game was last played, null if never played
+ * @property totalCorrectAnswers Total correct answers across all sessions
+ * @property totalAttempts Total problems attempted across all sessions
+ */
+data class GameStats(
+    val game: Game,
+    val personalBest: Int,
+    val totalGamesPlayed: Int,
+    val averageScore: Float,
+    val bestAccuracy: Float,
+    val lastPlayedAt: Instant?,
+    val totalCorrectAnswers: Int = 0,
+    val totalAttempts: Int = 0,
+) {
+    /**
+     * Calculates the overall accuracy across all game sessions.
+     *
+     * @return Overall accuracy as a percentage (0.0 - 100.0), or 0.0 if no attempts
+     */
+    val overallAccuracy: Float
+        get() =
+            if (totalAttempts > 0) {
+                (totalCorrectAnswers.toFloat() / totalAttempts) * 100f
+            } else {
+                0f
+            }
+
+    /**
+     * Checks if the user has ever played this game.
+     *
+     * @return true if the game has been played at least once
+     */
+    val hasPlayed: Boolean
+        get() = totalGamesPlayed > 0
+
+    /**
+     * Returns a star rating (1-5) based on best accuracy achieved.
+     *
+     * @return Number of stars (1-5), or 0 if never played
+     */
+    fun getStarRating(): Int =
+        when {
+            !hasPlayed -> 0
+            bestAccuracy >= 90f -> 5
+            bestAccuracy >= 80f -> 4
+            bestAccuracy >= 70f -> 3
+            bestAccuracy >= 60f -> 2
+            else -> 1
+        }
+
+    companion object {
+        /**
+         * Creates empty stats for a game that has never been played.
+         *
+         * @param game The game type
+         * @return GameStats with all zeroed values
+         */
+        fun empty(game: Game): GameStats =
+            GameStats(
+                game = game,
+                personalBest = 0,
+                totalGamesPlayed = 0,
+                averageScore = 0f,
+                bestAccuracy = 0f,
+                lastPlayedAt = null,
+                totalCorrectAnswers = 0,
+                totalAttempts = 0,
+            )
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/domain/repository/GameRepository.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/domain/repository/GameRepository.kt
@@ -1,0 +1,97 @@
+package dev.hossain.mathtutor.domain.repository
+
+import dev.hossain.mathtutor.domain.model.Game
+import dev.hossain.mathtutor.domain.model.GameSession
+import dev.hossain.mathtutor.domain.model.GameStats
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository interface for game session data management.
+ * Provides methods to save, retrieve, and analyze game session data.
+ */
+interface GameRepository {
+    /**
+     * Saves a completed game session to the database.
+     *
+     * @param session The game session to save
+     * @return The ID of the inserted session
+     */
+    suspend fun saveGameSession(session: GameSession): Long
+
+    /**
+     * Retrieves the personal best (highest score) for a specific game.
+     *
+     * @param game The game to get personal best for
+     * @return Flow of the highest score, or 0 if no sessions exist
+     */
+    fun getPersonalBest(game: Game): Flow<Int>
+
+    /**
+     * Retrieves the session with the personal best score for a specific game.
+     *
+     * @param game The game to get the best session for
+     * @return Flow of the best session, or null if no sessions exist
+     */
+    fun getBestSession(game: Game): Flow<GameSession?>
+
+    /**
+     * Retrieves aggregated statistics for a specific game.
+     *
+     * @param game The game to get stats for
+     * @return Flow of aggregated game statistics
+     */
+    fun getGameStats(game: Game): Flow<GameStats>
+
+    /**
+     * Retrieves the total number of games played for a specific game type.
+     *
+     * @param game The game to count sessions for
+     * @return Flow of the play count
+     */
+    fun getTotalGamesPlayed(game: Game): Flow<Int>
+
+    /**
+     * Checks if a game is unlocked based on total problems solved.
+     *
+     * @param game The game to check
+     * @return Flow of true if unlocked, false otherwise
+     */
+    fun isGameUnlocked(game: Game): Flow<Boolean>
+
+    /**
+     * Retrieves all sessions for a specific game type.
+     *
+     * @param game The game to get sessions for
+     * @return Flow of game sessions, ordered by most recent first
+     */
+    fun getSessionsByGame(game: Game): Flow<List<GameSession>>
+
+    /**
+     * Retrieves recent game sessions across all games.
+     *
+     * @param limit Maximum number of sessions to retrieve
+     * @return Flow of recent game sessions
+     */
+    fun getRecentSessions(limit: Int = 10): Flow<List<GameSession>>
+
+    /**
+     * Retrieves statistics for all games.
+     *
+     * @return Flow of map from Game to GameStats
+     */
+    fun getAllGameStats(): Flow<Map<Game, GameStats>>
+
+    /**
+     * Gets the count of perfect games (100% accuracy) for a specific game.
+     *
+     * @param game The game to check
+     * @return Flow of perfect game count
+     */
+    fun getPerfectGameCount(game: Game): Flow<Int>
+
+    /**
+     * Deletes all game sessions from the database.
+     * Useful for testing or user-requested data reset.
+     */
+    suspend fun clearAllSessions()
+}

--- a/app/src/test/java/dev/hossain/mathtutor/data/repository/GameRepositoryImplTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/data/repository/GameRepositoryImplTest.kt
@@ -1,0 +1,385 @@
+package dev.hossain.mathtutor.data.repository
+
+import dev.hossain.mathtutor.data.local.dao.GameSessionDao
+import dev.hossain.mathtutor.data.local.entity.GameSessionEntity
+import dev.hossain.mathtutor.domain.model.Game
+import dev.hossain.mathtutor.domain.model.GameSession
+import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.SessionStats
+import dev.hossain.mathtutor.domain.repository.SessionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+class GameRepositoryImplTest {
+    private lateinit var fakeGameSessionDao: FakeGameSessionDao
+    private lateinit var fakeSessionRepository: FakeSessionRepository
+    private lateinit var repository: GameRepositoryImpl
+
+    @Before
+    fun setup() {
+        fakeGameSessionDao = FakeGameSessionDao()
+        fakeSessionRepository = FakeSessionRepository()
+        repository = GameRepositoryImpl(fakeGameSessionDao, fakeSessionRepository)
+    }
+
+    // saveGameSession tests
+    @Test
+    fun `saveGameSession inserts entity correctly`() =
+        runTest {
+            val session = createGameSession(Game.MATH_RACE, score = 15)
+
+            val id = repository.saveGameSession(session)
+
+            assertEquals(1L, id)
+            assertEquals(1, fakeGameSessionDao.insertedSessions.size)
+            val inserted = fakeGameSessionDao.insertedSessions[0]
+            assertEquals("MATH_RACE", inserted.gameId)
+            assertEquals(15, inserted.score)
+        }
+
+    // getPersonalBest tests
+    @Test
+    fun `getPersonalBest returns highest score`() =
+        runTest {
+            fakeGameSessionDao.personalBests[Game.MATH_RACE.name] = MutableStateFlow(25)
+
+            val personalBest = repository.getPersonalBest(Game.MATH_RACE).first()
+
+            assertEquals(25, personalBest)
+        }
+
+    @Test
+    fun `getPersonalBest returns 0 when no sessions exist`() =
+        runTest {
+            fakeGameSessionDao.personalBests[Game.MATH_RACE.name] = MutableStateFlow(null)
+
+            val personalBest = repository.getPersonalBest(Game.MATH_RACE).first()
+
+            assertEquals(0, personalBest)
+        }
+
+    // getBestSession tests
+    @Test
+    fun `getBestSession returns session with highest score`() =
+        runTest {
+            val entity = createGameSessionEntity(id = 1, score = 30)
+            fakeGameSessionDao.bestSessions[Game.MATH_RACE.name] = MutableStateFlow(entity)
+
+            val bestSession = repository.getBestSession(Game.MATH_RACE).first()
+
+            assertEquals(30, bestSession?.score)
+            assertTrue(bestSession?.isNewRecord == true)
+        }
+
+    @Test
+    fun `getBestSession returns null when no sessions exist`() =
+        runTest {
+            fakeGameSessionDao.bestSessions[Game.MATH_RACE.name] = MutableStateFlow(null)
+
+            val bestSession = repository.getBestSession(Game.MATH_RACE).first()
+
+            assertNull(bestSession)
+        }
+
+    // getGameStats tests
+    @Test
+    fun `getGameStats returns aggregated statistics`() =
+        runTest {
+            val gameName = Game.MATH_RACE.name
+            fakeGameSessionDao.personalBests[gameName] = MutableStateFlow(25)
+            fakeGameSessionDao.totalGamesPlayed[gameName] = MutableStateFlow(5)
+            fakeGameSessionDao.averageScores[gameName] = MutableStateFlow(18f)
+            fakeGameSessionDao.bestAccuracies[gameName] = MutableStateFlow(95f)
+            fakeGameSessionDao.lastPlayedTimestamps[gameName] = MutableStateFlow(1000L)
+            fakeGameSessionDao.totalCorrectAnswers[gameName] = MutableStateFlow(80)
+            fakeGameSessionDao.totalAttempts[gameName] = MutableStateFlow(100)
+
+            val stats = repository.getGameStats(Game.MATH_RACE).first()
+
+            assertEquals(Game.MATH_RACE, stats.game)
+            assertEquals(25, stats.personalBest)
+            assertEquals(5, stats.totalGamesPlayed)
+            assertEquals(18f, stats.averageScore)
+            assertEquals(95f, stats.bestAccuracy)
+            assertEquals(80, stats.totalCorrectAnswers)
+            assertEquals(100, stats.totalAttempts)
+        }
+
+    @Test
+    fun `getGameStats returns default values when no data`() =
+        runTest {
+            val gameName = Game.MATH_RACE.name
+            fakeGameSessionDao.personalBests[gameName] = MutableStateFlow(null)
+            fakeGameSessionDao.totalGamesPlayed[gameName] = MutableStateFlow(0)
+            fakeGameSessionDao.averageScores[gameName] = MutableStateFlow(null)
+            fakeGameSessionDao.bestAccuracies[gameName] = MutableStateFlow(null)
+            fakeGameSessionDao.lastPlayedTimestamps[gameName] = MutableStateFlow(null)
+            fakeGameSessionDao.totalCorrectAnswers[gameName] = MutableStateFlow(null)
+            fakeGameSessionDao.totalAttempts[gameName] = MutableStateFlow(null)
+
+            val stats = repository.getGameStats(Game.MATH_RACE).first()
+
+            assertEquals(0, stats.personalBest)
+            assertEquals(0, stats.totalGamesPlayed)
+            assertEquals(0f, stats.averageScore)
+            assertEquals(0f, stats.bestAccuracy)
+            assertNull(stats.lastPlayedAt)
+        }
+
+    // getTotalGamesPlayed tests
+    @Test
+    fun `getTotalGamesPlayed returns correct count`() =
+        runTest {
+            fakeGameSessionDao.totalGamesPlayed[Game.MATH_RACE.name] = MutableStateFlow(10)
+
+            val count = repository.getTotalGamesPlayed(Game.MATH_RACE).first()
+
+            assertEquals(10, count)
+        }
+
+    // isGameUnlocked tests
+    @Test
+    fun `isGameUnlocked returns true when enough problems solved`() =
+        runTest {
+            fakeSessionRepository.setTotalProblems(100) // Math Race needs 50
+
+            val isUnlocked = repository.isGameUnlocked(Game.MATH_RACE).first()
+
+            assertTrue(isUnlocked)
+        }
+
+    @Test
+    fun `isGameUnlocked returns false when not enough problems solved`() =
+        runTest {
+            fakeSessionRepository.setTotalProblems(25) // Math Race needs 50
+
+            val isUnlocked = repository.isGameUnlocked(Game.MATH_RACE).first()
+
+            assertFalse(isUnlocked)
+        }
+
+    @Test
+    fun `isGameUnlocked with edge case - exactly at requirement`() =
+        runTest {
+            fakeSessionRepository.setTotalProblems(50) // Math Race needs exactly 50
+
+            val isUnlocked = repository.isGameUnlocked(Game.MATH_RACE).first()
+
+            assertTrue(isUnlocked)
+        }
+
+    @Test
+    fun `isGameUnlocked with edge case - one below requirement`() =
+        runTest {
+            fakeSessionRepository.setTotalProblems(49) // Math Race needs 50
+
+            val isUnlocked = repository.isGameUnlocked(Game.MATH_RACE).first()
+
+            assertFalse(isUnlocked)
+        }
+
+    // getSessionsByGame tests
+    @Test
+    fun `getSessionsByGame returns sessions for specific game`() =
+        runTest {
+            val entities =
+                listOf(
+                    createGameSessionEntity(id = 1, score = 15),
+                    createGameSessionEntity(id = 2, score = 20),
+                )
+            fakeGameSessionDao.sessionsByGame[Game.MATH_RACE.name] = MutableStateFlow(entities)
+
+            val sessions = repository.getSessionsByGame(Game.MATH_RACE).first()
+
+            assertEquals(2, sessions.size)
+            assertEquals(15, sessions[0].score)
+            assertEquals(20, sessions[1].score)
+        }
+
+    // getRecentSessions tests
+    @Test
+    fun `getRecentSessions returns limited sessions`() =
+        runTest {
+            val entities =
+                listOf(
+                    createGameSessionEntity(id = 1, score = 10),
+                    createGameSessionEntity(id = 2, score = 15),
+                )
+            fakeGameSessionDao.recentSessions = MutableStateFlow(entities)
+
+            val sessions = repository.getRecentSessions(10).first()
+
+            assertEquals(2, sessions.size)
+        }
+
+    // getPerfectGameCount tests
+    @Test
+    fun `getPerfectGameCount returns count of perfect games`() =
+        runTest {
+            fakeGameSessionDao.perfectGameCounts[Game.MATH_RACE.name] = MutableStateFlow(3)
+
+            val count = repository.getPerfectGameCount(Game.MATH_RACE).first()
+
+            assertEquals(3, count)
+        }
+
+    // clearAllSessions tests
+    @Test
+    fun `clearAllSessions calls DAO delete method`() =
+        runTest {
+            repository.clearAllSessions()
+
+            assertTrue(fakeGameSessionDao.deleteAllCalled)
+        }
+
+    // Helper methods
+    private fun createGameSession(
+        game: Game = Game.MATH_RACE,
+        score: Int = 10,
+        correctAnswers: Int = score,
+        totalAttempts: Int = score + 2,
+    ): GameSession =
+        GameSession(
+            id = 0,
+            game = game,
+            startTime = Instant.now(),
+            endTime = Instant.now(),
+            score = score,
+            correctAnswers = correctAnswers,
+            totalAttempts = totalAttempts,
+            durationSeconds = 60,
+            gradeLevel = GradeLevel.GRADE_1,
+        )
+
+    private fun createGameSessionEntity(
+        id: Long = 1,
+        gameId: String = Game.MATH_RACE.name,
+        score: Int = 10,
+        correctAnswers: Int = score,
+        totalAttempts: Int = score + 2,
+    ): GameSessionEntity =
+        GameSessionEntity(
+            id = id,
+            gameId = gameId,
+            startTime = Instant.now(),
+            endTime = Instant.now(),
+            score = score,
+            correctAnswers = correctAnswers,
+            totalAttempts = totalAttempts,
+            durationSeconds = 60,
+            gradeLevel = GradeLevel.GRADE_1,
+        )
+}
+
+/**
+ * Fake implementation of GameSessionDao for testing.
+ */
+class FakeGameSessionDao : GameSessionDao {
+    val insertedSessions = mutableListOf<GameSessionEntity>()
+    var allSessions = MutableStateFlow<List<GameSessionEntity>>(emptyList())
+    val sessionsByGame = mutableMapOf<String, MutableStateFlow<List<GameSessionEntity>>>()
+    var recentSessions = MutableStateFlow<List<GameSessionEntity>>(emptyList())
+    val personalBests = mutableMapOf<String, MutableStateFlow<Int?>>()
+    val bestSessions = mutableMapOf<String, MutableStateFlow<GameSessionEntity?>>()
+    val totalGamesPlayed = mutableMapOf<String, MutableStateFlow<Int>>()
+    val averageScores = mutableMapOf<String, MutableStateFlow<Float?>>()
+    val bestAccuracies = mutableMapOf<String, MutableStateFlow<Float?>>()
+    val lastPlayedTimestamps = mutableMapOf<String, MutableStateFlow<Long?>>()
+    val totalCorrectAnswers = mutableMapOf<String, MutableStateFlow<Int?>>()
+    val totalAttempts = mutableMapOf<String, MutableStateFlow<Int?>>()
+    val perfectGameCounts = mutableMapOf<String, MutableStateFlow<Int>>()
+    var deleteAllCalled = false
+    var deletedGameIds = mutableListOf<String>()
+
+    private var nextId = 1L
+
+    override suspend fun insertSession(session: GameSessionEntity): Long {
+        val id = nextId++
+        insertedSessions.add(session.copy(id = id))
+        return id
+    }
+
+    override fun getAllSessions(): Flow<List<GameSessionEntity>> = allSessions
+
+    override fun getSessionsByGame(gameId: String): Flow<List<GameSessionEntity>> =
+        sessionsByGame.getOrPut(gameId) { MutableStateFlow(emptyList()) }
+
+    override fun getRecentSessions(limit: Int): Flow<List<GameSessionEntity>> = recentSessions
+
+    override fun getPersonalBest(gameId: String): Flow<Int?> = personalBests.getOrPut(gameId) { MutableStateFlow(null) }
+
+    override fun getBestSession(gameId: String): Flow<GameSessionEntity?> = bestSessions.getOrPut(gameId) { MutableStateFlow(null) }
+
+    override fun getTotalGamesPlayed(gameId: String): Flow<Int> = totalGamesPlayed.getOrPut(gameId) { MutableStateFlow(0) }
+
+    override fun getAverageScore(gameId: String): Flow<Float?> = averageScores.getOrPut(gameId) { MutableStateFlow(null) }
+
+    override fun getBestAccuracy(gameId: String): Flow<Float?> = bestAccuracies.getOrPut(gameId) { MutableStateFlow(null) }
+
+    override fun getLastPlayedTimestamp(gameId: String): Flow<Long?> = lastPlayedTimestamps.getOrPut(gameId) { MutableStateFlow(null) }
+
+    override fun getTotalCorrectAnswers(gameId: String): Flow<Int?> = totalCorrectAnswers.getOrPut(gameId) { MutableStateFlow(null) }
+
+    override fun getTotalAttempts(gameId: String): Flow<Int?> = totalAttempts.getOrPut(gameId) { MutableStateFlow(null) }
+
+    override fun getTotalSessionCount(): Flow<Int> = flowOf(insertedSessions.size)
+
+    override fun getPerfectGameCount(gameId: String): Flow<Int> = perfectGameCounts.getOrPut(gameId) { MutableStateFlow(0) }
+
+    override suspend fun deleteAllSessions() {
+        deleteAllCalled = true
+        insertedSessions.clear()
+    }
+
+    override suspend fun deleteSessionsByGame(gameId: String) {
+        deletedGameIds.add(gameId)
+        insertedSessions.removeAll { it.gameId == gameId }
+    }
+}
+
+/**
+ * Fake implementation of SessionRepository for testing game unlock checks.
+ */
+class FakeSessionRepository : SessionRepository {
+    private val totalProblemsFlow = MutableStateFlow(SessionStats.EMPTY)
+
+    fun setTotalProblems(total: Int) {
+        totalProblemsFlow.value =
+            SessionStats(
+                totalProblems = total,
+                correctCount = total,
+                accuracy = 100f,
+                sessionCount = total / 10,
+            )
+    }
+
+    override suspend fun saveSession(
+        session: dev.hossain.mathtutor.domain.model.PracticeSession,
+        operation: dev.hossain.mathtutor.domain.model.MathOperation,
+        durationSeconds: Long,
+        gradeLevel: Int?,
+    ): Long = 1L
+
+    override fun getAllSessions() = flowOf(emptyList<dev.hossain.mathtutor.data.local.entity.PracticeSessionEntity>())
+
+    override fun getRecentSessions(limit: Int) = flowOf(emptyList<dev.hossain.mathtutor.data.local.entity.PracticeSessionEntity>())
+
+    override fun getSessionsByOperation(operation: dev.hossain.mathtutor.domain.model.MathOperation) =
+        flowOf(emptyList<dev.hossain.mathtutor.data.local.entity.PracticeSessionEntity>())
+
+    override fun getOverallStats(): Flow<SessionStats> = totalProblemsFlow
+
+    override fun getStatsByOperation(operation: dev.hossain.mathtutor.domain.model.MathOperation) = flowOf(SessionStats.EMPTY)
+
+    override suspend fun clearAllSessions() {}
+}

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/GameSessionTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/GameSessionTest.kt
@@ -1,0 +1,130 @@
+package dev.hossain.mathtutor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class GameSessionTest {
+    @Test
+    fun `accuracy is calculated correctly with all correct answers`() {
+        val session = createSession(correctAnswers = 10, totalAttempts = 10)
+        assertEquals(100f, session.accuracy)
+    }
+
+    @Test
+    fun `accuracy is calculated correctly with partial correct answers`() {
+        val session = createSession(correctAnswers = 15, totalAttempts = 18)
+        assertEquals(83.333336f, session.accuracy, 0.001f)
+    }
+
+    @Test
+    fun `accuracy returns 0 when no attempts`() {
+        val session = createSession(correctAnswers = 0, totalAttempts = 0)
+        assertEquals(0f, session.accuracy)
+    }
+
+    @Test
+    fun `averageTimePerProblem is calculated correctly`() {
+        val session = createSession(durationSeconds = 60, totalAttempts = 20)
+        assertEquals(3f, session.averageTimePerProblem)
+    }
+
+    @Test
+    fun `averageTimePerProblem returns 0 when no attempts`() {
+        val session = createSession(durationSeconds = 60, totalAttempts = 0)
+        assertEquals(0f, session.averageTimePerProblem)
+    }
+
+    @Test
+    fun `problemsPerMinute is calculated correctly`() {
+        val session = createSession(durationSeconds = 60, totalAttempts = 20)
+        assertEquals(20f, session.problemsPerMinute)
+    }
+
+    @Test
+    fun `problemsPerMinute returns 0 when duration is 0`() {
+        val session = createSession(durationSeconds = 0, totalAttempts = 20)
+        assertEquals(0f, session.problemsPerMinute)
+    }
+
+    @Test
+    fun `isPerfectGame returns true when all correct`() {
+        val session = createSession(correctAnswers = 15, totalAttempts = 15)
+        assertTrue(session.isPerfectGame)
+    }
+
+    @Test
+    fun `isPerfectGame returns false when not all correct`() {
+        val session = createSession(correctAnswers = 14, totalAttempts = 15)
+        assertFalse(session.isPerfectGame)
+    }
+
+    @Test
+    fun `isPerfectGame returns false when no attempts`() {
+        val session = createSession(correctAnswers = 0, totalAttempts = 0)
+        assertFalse(session.isPerfectGame)
+    }
+
+    @Test
+    fun `getStarRating returns 5 for 90+ accuracy`() {
+        val session = createSession(correctAnswers = 9, totalAttempts = 10)
+        assertEquals(5, session.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 4 for 80-89 accuracy`() {
+        val session = createSession(correctAnswers = 8, totalAttempts = 10)
+        assertEquals(4, session.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 3 for 70-79 accuracy`() {
+        val session = createSession(correctAnswers = 7, totalAttempts = 10)
+        assertEquals(3, session.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 2 for 60-69 accuracy`() {
+        val session = createSession(correctAnswers = 6, totalAttempts = 10)
+        assertEquals(2, session.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 1 for less than 60 accuracy`() {
+        val session = createSession(correctAnswers = 5, totalAttempts = 10)
+        assertEquals(1, session.getStarRating())
+    }
+
+    @Test
+    fun `startNew creates session with default values`() {
+        val session = GameSession.startNew(Game.MATH_RACE, GradeLevel.GRADE_1)
+
+        assertEquals(Game.MATH_RACE, session.game)
+        assertEquals(GradeLevel.GRADE_1, session.gradeLevel)
+        assertEquals(0, session.score)
+        assertEquals(0, session.correctAnswers)
+        assertEquals(0, session.totalAttempts)
+        assertEquals(0, session.durationSeconds)
+        assertFalse(session.isNewRecord)
+    }
+
+    private fun createSession(
+        correctAnswers: Int = 0,
+        totalAttempts: Int = 0,
+        durationSeconds: Int = 60,
+        score: Int = correctAnswers,
+    ): GameSession =
+        GameSession(
+            id = 1,
+            game = Game.MATH_RACE,
+            startTime = Instant.now(),
+            endTime = Instant.now(),
+            score = score,
+            correctAnswers = correctAnswers,
+            totalAttempts = totalAttempts,
+            durationSeconds = durationSeconds,
+            gradeLevel = GradeLevel.GRADE_1,
+        )
+}

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/GameStatsTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/GameStatsTest.kt
@@ -1,0 +1,105 @@
+package dev.hossain.mathtutor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class GameStatsTest {
+    @Test
+    fun `overallAccuracy is calculated correctly`() {
+        val stats = createStats(totalCorrectAnswers = 80, totalAttempts = 100)
+        assertEquals(80f, stats.overallAccuracy)
+    }
+
+    @Test
+    fun `overallAccuracy returns 0 when no attempts`() {
+        val stats = createStats(totalCorrectAnswers = 0, totalAttempts = 0)
+        assertEquals(0f, stats.overallAccuracy)
+    }
+
+    @Test
+    fun `hasPlayed returns true when totalGamesPlayed greater than 0`() {
+        val stats = createStats(totalGamesPlayed = 1)
+        assertTrue(stats.hasPlayed)
+    }
+
+    @Test
+    fun `hasPlayed returns false when totalGamesPlayed is 0`() {
+        val stats = createStats(totalGamesPlayed = 0)
+        assertFalse(stats.hasPlayed)
+    }
+
+    @Test
+    fun `getStarRating returns 0 when never played`() {
+        val stats = createStats(totalGamesPlayed = 0, bestAccuracy = 100f)
+        assertEquals(0, stats.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 5 for 90+ best accuracy`() {
+        val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 95f)
+        assertEquals(5, stats.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 4 for 80-89 best accuracy`() {
+        val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 85f)
+        assertEquals(4, stats.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 3 for 70-79 best accuracy`() {
+        val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 75f)
+        assertEquals(3, stats.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 2 for 60-69 best accuracy`() {
+        val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 65f)
+        assertEquals(2, stats.getStarRating())
+    }
+
+    @Test
+    fun `getStarRating returns 1 for less than 60 best accuracy`() {
+        val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 50f)
+        assertEquals(1, stats.getStarRating())
+    }
+
+    @Test
+    fun `empty creates stats with all zeroed values`() {
+        val stats = GameStats.empty(Game.MATH_RACE)
+
+        assertEquals(Game.MATH_RACE, stats.game)
+        assertEquals(0, stats.personalBest)
+        assertEquals(0, stats.totalGamesPlayed)
+        assertEquals(0f, stats.averageScore)
+        assertEquals(0f, stats.bestAccuracy)
+        assertNull(stats.lastPlayedAt)
+        assertEquals(0, stats.totalCorrectAnswers)
+        assertEquals(0, stats.totalAttempts)
+    }
+
+    private fun createStats(
+        game: Game = Game.MATH_RACE,
+        personalBest: Int = 20,
+        totalGamesPlayed: Int = 5,
+        averageScore: Float = 15f,
+        bestAccuracy: Float = 90f,
+        lastPlayedAt: Instant? = Instant.now(),
+        totalCorrectAnswers: Int = 100,
+        totalAttempts: Int = 120,
+    ): GameStats =
+        GameStats(
+            game = game,
+            personalBest = personalBest,
+            totalGamesPlayed = totalGamesPlayed,
+            averageScore = averageScore,
+            bestAccuracy = bestAccuracy,
+            lastPlayedAt = lastPlayedAt,
+            totalCorrectAnswers = totalCorrectAnswers,
+            totalAttempts = totalAttempts,
+        )
+}

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/GameTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/GameTest.kt
@@ -1,0 +1,111 @@
+package dev.hossain.mathtutor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameTest {
+    @Test
+    fun `Game has correct values`() {
+        assertEquals(3, Game.entries.size)
+    }
+
+    @Test
+    fun `Game values are correctly named`() {
+        assertEquals(Game.MATH_RACE, Game.valueOf("MATH_RACE"))
+        assertEquals(Game.MEMORY_MATCH, Game.valueOf("MEMORY_MATCH"))
+        assertEquals(Game.NUMBER_SEQUENCE, Game.valueOf("NUMBER_SEQUENCE"))
+    }
+
+    @Test
+    fun `Game displayNames are set correctly`() {
+        assertEquals("Math Race", Game.MATH_RACE.displayName)
+        assertEquals("Memory Match", Game.MEMORY_MATCH.displayName)
+        assertEquals("Number Sequence", Game.NUMBER_SEQUENCE.displayName)
+    }
+
+    @Test
+    fun `Game icons are set correctly`() {
+        assertEquals("⏱️", Game.MATH_RACE.icon)
+        assertEquals("🧩", Game.MEMORY_MATCH.icon)
+        assertEquals("🎲", Game.NUMBER_SEQUENCE.icon)
+    }
+
+    @Test
+    fun `Game unlock requirements are correct`() {
+        assertEquals(50, Game.MATH_RACE.unlockRequirement)
+        assertEquals(100, Game.MEMORY_MATCH.unlockRequirement)
+        assertEquals(200, Game.NUMBER_SEQUENCE.unlockRequirement)
+    }
+
+    @Test
+    fun `Game durations are correct`() {
+        assertEquals(60, Game.MATH_RACE.durationSeconds)
+        assertEquals(120, Game.MEMORY_MATCH.durationSeconds)
+        assertEquals(90, Game.NUMBER_SEQUENCE.durationSeconds)
+    }
+
+    // isUnlocked tests
+    @Test
+    fun `isUnlocked returns false when problems solved is below requirement`() {
+        assertFalse(Game.MATH_RACE.isUnlocked(0))
+        assertFalse(Game.MATH_RACE.isUnlocked(49))
+        assertFalse(Game.MEMORY_MATCH.isUnlocked(99))
+        assertFalse(Game.NUMBER_SEQUENCE.isUnlocked(199))
+    }
+
+    @Test
+    fun `isUnlocked returns true when problems solved equals requirement`() {
+        assertTrue(Game.MATH_RACE.isUnlocked(50))
+        assertTrue(Game.MEMORY_MATCH.isUnlocked(100))
+        assertTrue(Game.NUMBER_SEQUENCE.isUnlocked(200))
+    }
+
+    @Test
+    fun `isUnlocked returns true when problems solved exceeds requirement`() {
+        assertTrue(Game.MATH_RACE.isUnlocked(100))
+        assertTrue(Game.MEMORY_MATCH.isUnlocked(200))
+        assertTrue(Game.NUMBER_SEQUENCE.isUnlocked(500))
+    }
+
+    // unlockProgress tests
+    @Test
+    fun `unlockProgress returns 0 when no problems solved`() {
+        assertEquals(0f, Game.MATH_RACE.unlockProgress(0))
+    }
+
+    @Test
+    fun `unlockProgress returns correct fraction`() {
+        assertEquals(0.5f, Game.MATH_RACE.unlockProgress(25))
+        assertEquals(0.5f, Game.MEMORY_MATCH.unlockProgress(50))
+        assertEquals(0.5f, Game.NUMBER_SEQUENCE.unlockProgress(100))
+    }
+
+    @Test
+    fun `unlockProgress caps at 1 when requirement met`() {
+        assertEquals(1f, Game.MATH_RACE.unlockProgress(50))
+        assertEquals(1f, Game.MATH_RACE.unlockProgress(100))
+    }
+
+    // problemsUntilUnlock tests
+    @Test
+    fun `problemsUntilUnlock returns requirement when no problems solved`() {
+        assertEquals(50, Game.MATH_RACE.problemsUntilUnlock(0))
+        assertEquals(100, Game.MEMORY_MATCH.problemsUntilUnlock(0))
+        assertEquals(200, Game.NUMBER_SEQUENCE.problemsUntilUnlock(0))
+    }
+
+    @Test
+    fun `problemsUntilUnlock returns remaining problems`() {
+        assertEquals(25, Game.MATH_RACE.problemsUntilUnlock(25))
+        assertEquals(50, Game.MEMORY_MATCH.problemsUntilUnlock(50))
+        assertEquals(100, Game.NUMBER_SEQUENCE.problemsUntilUnlock(100))
+    }
+
+    @Test
+    fun `problemsUntilUnlock returns 0 when requirement met`() {
+        assertEquals(0, Game.MATH_RACE.problemsUntilUnlock(50))
+        assertEquals(0, Game.MATH_RACE.problemsUntilUnlock(100))
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 6-1: Game Data Layer & Repository - the foundation for mini-games feature.

Closes #61

## Changes

### Domain Models
- **`Game` enum** - Defines MATH_RACE, MEMORY_MATCH, NUMBER_SEQUENCE with:
  - Display names, descriptions, and icons
  - Unlock requirements (50, 100, 200 problems)
  - `isUnlocked()`, `unlockProgress()`, `problemsUntilUnlock()` methods
  
- **`GameSession` data class** - Represents a completed game session with:
  - Score, correct answers, total attempts, duration
  - Computed properties: `accuracy`, `averageTimePerProblem`, `problemsPerMinute`, `isPerfectGame`
  - Star rating calculation (1-5 stars based on accuracy)
  
- **`GameStats` data class** - Aggregated statistics per game:
  - Personal best, total games played, average score
  - Best accuracy, last played timestamp
  - Overall accuracy calculation

### Database Layer
- **`GameSessionEntity`** - Room entity with indexed `gameId` column
- **`GameSessionDao`** - 18 query methods including:
  - Personal best, average score, best accuracy
  - Total games played, perfect game count
  - Recent sessions, sessions by game
- **Migration v4 → v5** - Creates `game_sessions` table with index

### Repository Layer
- **`GameRepository` interface** - Flow-based reactive data access
- **`GameRepositoryImpl`** - Implementation with Metro DI:
  - Integrates with `SessionRepository.getOverallStats().totalProblems` for unlock checks
  - Combines multiple flows for `GameStats` aggregation

### DI Integration
- Updated `DatabaseModule` with MIGRATION_4_5 and `GameSessionDao` provider

## Tests

Added 51 new unit tests:

| Test Class | Tests | Coverage |
|------------|-------|----------|
| `GameTest` | 15 | Unlock logic, progress calculation |
| `GameSessionTest` | 12 | Accuracy, star ratings, computed properties |
| `GameStatsTest` | 9 | Aggregation, star ratings |
| `GameRepositoryImplTest` | 15 | Repository methods with fakes |

## Database Schema

```sql
CREATE TABLE game_sessions (
    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
    gameId TEXT NOT NULL,
    startTime INTEGER NOT NULL,
    endTime INTEGER NOT NULL,
    score INTEGER NOT NULL,
    correctAnswers INTEGER NOT NULL,
    totalAttempts INTEGER NOT NULL,
    durationSeconds INTEGER NOT NULL,
    gradeLevel TEXT NOT NULL
);
CREATE INDEX index_game_sessions_gameId ON game_sessions (gameId);
```

## Checklist

- [x] Code follows project style guidelines
- [x] `./gradlew formatKotlin` passed
- [x] `./gradlew assembleDebug` passed
- [x] All unit tests passing
- [x] CHANGELOG.md updated
- [x] No hardcoded colors (Material 3 compliant)
