### PR TITLE
Phase 6-3: Math Race UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Phase 6-3: Math Race UI** - Visual UI for the Math Race mini-game (#63)
+  - **MathRaceUi** (`ui/mathrace/MathRaceUi.kt`):
+    - Main UI with `@CircuitInject` routing based on GameState
+    - Routes to appropriate screen for each state (NotStarted, Countdown, Playing, Finished)
+  - **MathRaceStartScreen** (`ui/mathrace/MathRaceStartScreen.kt`):
+    - Game title "Math Race ⏱️" with emoji
+    - Game description explaining 60-second challenge
+    - Personal best display with trophy icon (if > 0)
+    - Large "START GAME" button with Material 3 styling
+    - Back navigation to home
+  - **CountdownScreen** (`ui/mathrace/CountdownScreen.kt`):
+    - Large animated countdown numbers (3, 2, 1, GO!)
+    - Scale animation using animateFloatAsState
+    - displayLarge typography for maximum visibility
+    - Tertiary color for "GO!" text
+    - LiveRegion for TalkBack accessibility
+  - **MathRaceGameScreen** (`ui/mathrace/MathRaceGameScreen.kt`):
+    - Header row with timer and score displays
+    - Timer with pulse animation when ≤10 seconds
+    - Timer color changes from primary to error when ≤10 seconds
+    - Problem display card with spoken content description
+    - Answer field using existing AnswerField component
+    - Number pad using existing NumberPad component
+    - Backspace and Check buttons with haptic feedback
+    - Personal best footer display
+  - **MathRaceResultsScreen** (`ui/mathrace/MathRaceResultsScreen.kt`):
+    - "Game Over! 🎉" animated title
+    - Final score with pulse animation for new records
+    - New Record badge with animated trophy icon
+    - Stats card with correct answers, accuracy %, and average time
+    - Staggered entrance animations for content
+    - "Play Again" and "Home" buttons
+  - **Animations**:
+    - Countdown scale animation (0.5 → 1.2 → 1.0)
+    - Timer pulse animation when warning state (< 10s)
+    - Score pulse animation for new records
+    - Trophy bounce animation for new record badge
+    - Staggered fade-in and slide animations on results screen
+  - **Material 3 Compliance**:
+    - All colors from MaterialTheme.colorScheme
+    - Typography from MaterialTheme.typography
+    - No hardcoded colors used
+  - **Accessibility**:
+    - Content descriptions for all interactive elements
+    - LiveRegion for timer warnings
+    - Semantic headings for screen titles
+    - Role annotations for buttons
 - **Phase 6-2: Math Race Game Logic** - Core game mechanics for the Math Race mini-game (#62)
   - **AudioService Extensions**:
     - Added `playCountdown()` for 3-2-1 countdown audio

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/CountdownScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/CountdownScreen.kt
@@ -1,0 +1,144 @@
+package dev.hossain.mathtutor.ui.mathrace
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
+
+/**
+ * Countdown screen displaying 3-2-1-GO! animation.
+ *
+ * Shows large animated numbers with scale effect that pulses on each count.
+ * Uses displayLarge typography for maximum visibility.
+ *
+ * @param countdownValue Current countdown number (3, 2, 1, or 0 for GO!)
+ * @param modifier Optional modifier
+ */
+@Composable
+fun CountdownScreen(
+    countdownValue: Int,
+    modifier: Modifier = Modifier,
+) {
+    // Determine display text
+    val displayText = if (countdownValue > 0) countdownValue.toString() else "GO!"
+
+    // Scale animation state - starts big and pulses
+    var targetScale by remember(countdownValue) { mutableFloatStateOf(0.5f) }
+    val scale by animateFloatAsState(
+        targetValue = targetScale,
+        animationSpec =
+            tween(
+                durationMillis = 300,
+                easing = FastOutSlowInEasing,
+            ),
+        label = "countdown_scale",
+    )
+
+    // Trigger animation when countdown value changes
+    LaunchedEffect(countdownValue) {
+        targetScale = 1.2f
+        kotlinx.coroutines.delay(150)
+        targetScale = 1.0f
+    }
+
+    // Text color - green for GO!, primary for numbers
+    val textColor =
+        if (countdownValue == 0) {
+            MaterialTheme.colorScheme.tertiary
+        } else {
+            MaterialTheme.colorScheme.primary
+        }
+
+    // Accessibility description
+    val contentDesc =
+        if (countdownValue > 0) {
+            "$countdownValue"
+        } else {
+            "Go! Game starting"
+        }
+
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = displayText,
+                style =
+                    MaterialTheme.typography.displayLarge.copy(
+                        fontWeight = FontWeight.Bold,
+                    ),
+                color = textColor,
+                modifier =
+                    Modifier
+                        .scale(scale)
+                        .semantics {
+                            contentDescription = contentDesc
+                            liveRegion = androidx.compose.ui.semantics.LiveRegionMode.Assertive
+                        },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountdownScreen3Preview() {
+    KidsMathTutorAppTheme {
+        CountdownScreen(countdownValue = 3)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountdownScreen2Preview() {
+    KidsMathTutorAppTheme {
+        CountdownScreen(countdownValue = 2)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountdownScreen1Preview() {
+    KidsMathTutorAppTheme {
+        CountdownScreen(countdownValue = 1)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountdownScreenGoPreview() {
+    KidsMathTutorAppTheme {
+        CountdownScreen(countdownValue = 0)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountdownScreenDarkPreview() {
+    KidsMathTutorAppTheme(darkTheme = true) {
+        CountdownScreen(countdownValue = 3)
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceGameScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceGameScreen.kt
@@ -1,0 +1,510 @@
+package dev.hossain.mathtutor.ui.mathrace
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Backspace
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.hossain.mathtutor.domain.model.MathOperation
+import dev.hossain.mathtutor.domain.model.MathProblem
+import dev.hossain.mathtutor.haptic.HapticService
+import dev.hossain.mathtutor.ui.component.AnswerField
+import dev.hossain.mathtutor.ui.component.NumberPad
+import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
+
+/**
+ * Main game screen for Math Race.
+ *
+ * Shows timer, score, current problem, answer field, number pad, and personal best.
+ * Timer changes color and pulses when below 10 seconds.
+ *
+ * @param currentProblem Current math problem to solve
+ * @param currentAnswer Player's current answer input
+ * @param score Current score (correct answers)
+ * @param timeRemaining Seconds remaining in the game
+ * @param personalBest Player's personal best score
+ * @param lastAnswerCorrect Whether the last answer was correct (for feedback)
+ * @param onNumberEntered Callback when a digit is entered
+ * @param onBackspace Callback when backspace is pressed
+ * @param onCheckAnswer Callback when check/submit is pressed
+ * @param modifier Optional modifier
+ * @param hapticService Optional haptic service for feedback
+ */
+@Composable
+fun MathRaceGameScreen(
+    currentProblem: MathProblem?,
+    currentAnswer: String,
+    score: Int,
+    timeRemaining: Int,
+    personalBest: Int,
+    lastAnswerCorrect: Boolean?,
+    onNumberEntered: (Int) -> Unit,
+    onBackspace: () -> Unit,
+    onCheckAnswer: () -> Unit,
+    modifier: Modifier = Modifier,
+    hapticService: HapticService? = null,
+) {
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            // Header: Timer and Score
+            GameHeader(
+                timeRemaining = timeRemaining,
+                score = score,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Problem display
+            if (currentProblem != null) {
+                ProblemDisplay(
+                    problem = currentProblem,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Answer field
+            AnswerField(
+                answer = currentAnswer,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Number pad
+            NumberPad(
+                onNumberClick = onNumberEntered,
+                modifier = Modifier.fillMaxWidth(),
+                hapticService = hapticService,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Action buttons row
+            ActionButtonsRow(
+                hasAnswer = currentAnswer.isNotEmpty(),
+                onBackspace = onBackspace,
+                onCheckAnswer = onCheckAnswer,
+                hapticService = hapticService,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Personal best at bottom
+            if (personalBest > 0) {
+                PersonalBestFooter(personalBest = personalBest)
+            }
+        }
+    }
+}
+
+/**
+ * Header row showing timer and score with appropriate styling.
+ */
+@Composable
+private fun GameHeader(
+    timeRemaining: Int,
+    score: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Timer display with warning state
+        TimerDisplay(
+            timeRemaining = timeRemaining,
+            modifier = Modifier.weight(1f),
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        // Score display
+        ScoreDisplay(
+            score = score,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/**
+ * Timer display with color change and pulse animation when < 10 seconds.
+ */
+@Composable
+private fun TimerDisplay(
+    timeRemaining: Int,
+    modifier: Modifier = Modifier,
+) {
+    val isWarning = timeRemaining <= 10
+
+    // Animate color between primary and error
+    val timerColor by animateColorAsState(
+        targetValue =
+            if (isWarning) {
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.primary
+            },
+        animationSpec = tween(durationMillis = 300),
+        label = "timer_color",
+    )
+
+    // Pulse animation when warning
+    val infiniteTransition = rememberInfiniteTransition(label = "timer_pulse")
+    val scale by infiniteTransition.animateFloat(
+        initialValue = 1.0f,
+        targetValue = if (isWarning) 1.1f else 1.0f,
+        animationSpec =
+            infiniteRepeatable(
+                animation =
+                    tween(
+                        durationMillis = 500,
+                        easing = FastOutSlowInEasing,
+                    ),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "timer_scale",
+    )
+
+    // Format time as M:SS
+    val minutes = timeRemaining / 60
+    val seconds = timeRemaining % 60
+    val timeText = String.format("%d:%02d", minutes, seconds)
+
+    Row(
+        modifier =
+            modifier
+                .scale(scale)
+                .semantics {
+                    contentDescription =
+                        if (isWarning) {
+                            "Warning: $timeRemaining seconds remaining"
+                        } else {
+                            "$timeRemaining seconds remaining"
+                        }
+                    liveRegion =
+                        if (isWarning) {
+                            androidx.compose.ui.semantics.LiveRegionMode.Assertive
+                        } else {
+                            androidx.compose.ui.semantics.LiveRegionMode.Polite
+                        }
+                },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.AccessTime,
+            contentDescription = null,
+            tint = timerColor,
+            modifier = Modifier.size(28.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = timeText,
+            style = MaterialTheme.typography.headlineMedium,
+            color = timerColor,
+        )
+    }
+}
+
+/**
+ * Score display with star icon.
+ */
+@Composable
+private fun ScoreDisplay(
+    score: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier.semantics {
+                contentDescription = "Score: $score"
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.End,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Star,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.tertiary,
+            modifier = Modifier.size(28.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "Score: $score",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.tertiary,
+        )
+    }
+}
+
+/**
+ * Displays the current math problem in a card.
+ */
+@Composable
+private fun ProblemDisplay(
+    problem: MathProblem,
+    modifier: Modifier = Modifier,
+) {
+    val displayText = problem.getDisplayString()
+    val spokenText = problem.getSpokenString()
+
+    Card(
+        modifier =
+            modifier.semantics(mergeDescendants = true) {
+                contentDescription = spokenText
+                heading()
+            },
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(32.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = displayText,
+                style = MaterialTheme.typography.displayLarge,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/**
+ * Action buttons row with backspace and check buttons.
+ */
+@Composable
+private fun ActionButtonsRow(
+    hasAnswer: Boolean,
+    onBackspace: () -> Unit,
+    onCheckAnswer: () -> Unit,
+    modifier: Modifier = Modifier,
+    hapticService: HapticService? = null,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // Backspace button
+        Button(
+            onClick = {
+                hapticService?.triggerButtonClick()
+                onBackspace()
+            },
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .height(56.dp)
+                    .semantics {
+                        contentDescription = "Delete last digit"
+                        role = Role.Button
+                    },
+            enabled = hasAnswer,
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.Backspace,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+
+        // Check answer button
+        Button(
+            onClick = {
+                hapticService?.triggerButtonClick()
+                onCheckAnswer()
+            },
+            modifier =
+                Modifier
+                    .weight(2f)
+                    .height(56.dp)
+                    .semantics {
+                        contentDescription = "Check answer"
+                        role = Role.Button
+                    },
+            enabled = hasAnswer,
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Check,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Check",
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+    }
+}
+
+/**
+ * Personal best display at the bottom of the screen.
+ */
+@Composable
+private fun PersonalBestFooter(
+    personalBest: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier.semantics {
+                contentDescription = "Personal best: $personalBest"
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.EmojiEvents,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = "Personal Best: $personalBest",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceGameScreenPreview() {
+    KidsMathTutorAppTheme {
+        MathRaceGameScreen(
+            currentProblem =
+                MathProblem(
+                    num1 = 8,
+                    num2 = 4,
+                    operation = MathOperation.ADDITION,
+                    correctAnswer = 12,
+                ),
+            currentAnswer = "12",
+            score = 15,
+            timeRemaining = 47,
+            personalBest = 18,
+            lastAnswerCorrect = null,
+            onNumberEntered = {},
+            onBackspace = {},
+            onCheckAnswer = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceGameScreenWarningPreview() {
+    KidsMathTutorAppTheme {
+        MathRaceGameScreen(
+            currentProblem =
+                MathProblem(
+                    num1 = 5,
+                    num2 = 3,
+                    operation = MathOperation.SUBTRACTION,
+                    correctAnswer = 2,
+                ),
+            currentAnswer = "",
+            score = 21,
+            timeRemaining = 8,
+            personalBest = 18,
+            lastAnswerCorrect = true,
+            onNumberEntered = {},
+            onBackspace = {},
+            onCheckAnswer = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceGameScreenDarkPreview() {
+    KidsMathTutorAppTheme(darkTheme = true) {
+        MathRaceGameScreen(
+            currentProblem =
+                MathProblem(
+                    num1 = 7,
+                    num2 = 6,
+                    operation = MathOperation.MULTIPLICATION,
+                    correctAnswer = 42,
+                ),
+            currentAnswer = "42",
+            score = 10,
+            timeRemaining = 35,
+            personalBest = 25,
+            lastAnswerCorrect = null,
+            onNumberEntered = {},
+            onBackspace = {},
+            onCheckAnswer = {},
+        )
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceResultsScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceResultsScreen.kt
@@ -1,0 +1,524 @@
+package dev.hossain.mathtutor.ui.mathrace
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
+import kotlinx.coroutines.delay
+
+/**
+ * Results screen shown after a Math Race game ends.
+ *
+ * Displays final score, new record indicator (if applicable),
+ * game statistics, and navigation buttons.
+ *
+ * @param finalScore Final score achieved
+ * @param totalAttempts Total problems attempted
+ * @param isNewRecord Whether this is a new personal best
+ * @param accuracy Percentage of correct answers (0-100)
+ * @param averageTimePerProblem Average seconds per problem
+ * @param personalBest Player's personal best (previous or new)
+ * @param userName Player's name
+ * @param onPlayAgain Callback to start a new game
+ * @param onNavigateHome Callback to return to home
+ * @param modifier Optional modifier
+ */
+@Composable
+fun MathRaceResultsScreen(
+    finalScore: Int,
+    totalAttempts: Int,
+    isNewRecord: Boolean,
+    accuracy: Float,
+    averageTimePerProblem: Float,
+    personalBest: Int,
+    userName: String?,
+    onPlayAgain: () -> Unit,
+    onNavigateHome: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Animation states
+    var showContent by remember { mutableStateOf(false) }
+    var showNewRecord by remember { mutableStateOf(false) }
+    var showStats by remember { mutableStateOf(false) }
+    var showButtons by remember { mutableStateOf(false) }
+
+    // Stagger animations
+    LaunchedEffect(Unit) {
+        showContent = true
+        delay(300)
+        showNewRecord = true
+        delay(200)
+        showStats = true
+        delay(200)
+        showButtons = true
+    }
+
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            // Game Over title
+            AnimatedVisibility(
+                visible = showContent,
+                enter = fadeIn() + slideInVertically { -it },
+            ) {
+                Text(
+                    text = "Game Over! 🎉",
+                    style = MaterialTheme.typography.displaySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    textAlign = TextAlign.Center,
+                    modifier =
+                        Modifier.semantics {
+                            heading()
+                            contentDescription = "Game Over"
+                        },
+                )
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Final score display
+            AnimatedVisibility(
+                visible = showContent,
+                enter = fadeIn() + slideInVertically { -it / 2 },
+            ) {
+                ScoreSection(
+                    score = finalScore,
+                    isNewRecord = isNewRecord && showNewRecord,
+                    previousBest = if (isNewRecord) personalBest - finalScore + finalScore else personalBest,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // New record indicator
+            if (isNewRecord) {
+                AnimatedVisibility(
+                    visible = showNewRecord,
+                    enter = fadeIn() + slideInVertically { it },
+                ) {
+                    NewRecordBadge()
+                }
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            // Stats card
+            AnimatedVisibility(
+                visible = showStats,
+                enter = fadeIn() + slideInVertically { it / 2 },
+            ) {
+                StatsCard(
+                    correctAnswers = finalScore,
+                    totalAttempts = totalAttempts,
+                    accuracy = accuracy,
+                    averageTime = averageTimePerProblem,
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Action buttons
+            AnimatedVisibility(
+                visible = showButtons,
+                enter = fadeIn(),
+            ) {
+                ActionButtons(
+                    onPlayAgain = onPlayAgain,
+                    onNavigateHome = onNavigateHome,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Displays the final score prominently.
+ */
+@Composable
+private fun ScoreSection(
+    score: Int,
+    isNewRecord: Boolean,
+    previousBest: Int,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Score label
+        Text(
+            text = "Score",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Score value with animation
+        val infiniteTransition = rememberInfiniteTransition(label = "score_pulse")
+        val scale by infiniteTransition.animateFloat(
+            initialValue = 1.0f,
+            targetValue = if (isNewRecord) 1.05f else 1.0f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation =
+                        tween(
+                            durationMillis = 800,
+                            easing = FastOutSlowInEasing,
+                        ),
+                    repeatMode = RepeatMode.Reverse,
+                ),
+            label = "score_scale",
+        )
+
+        Text(
+            text = score.toString(),
+            style =
+                MaterialTheme.typography.displayLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+            color =
+                if (isNewRecord) {
+                    MaterialTheme.colorScheme.tertiary
+                } else {
+                    MaterialTheme.colorScheme.primary
+                },
+            modifier =
+                Modifier
+                    .scale(scale)
+                    .semantics {
+                        contentDescription = "Final score: $score"
+                    },
+        )
+    }
+}
+
+/**
+ * Animated new record badge with trophy icon.
+ */
+@Composable
+private fun NewRecordBadge(modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition(label = "trophy_bounce")
+    val scale by infiniteTransition.animateFloat(
+        initialValue = 1.0f,
+        targetValue = 1.15f,
+        animationSpec =
+            infiniteRepeatable(
+                animation =
+                    tween(
+                        durationMillis = 600,
+                        easing = FastOutSlowInEasing,
+                    ),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "trophy_scale",
+    )
+
+    Card(
+        modifier =
+            modifier
+                .scale(scale)
+                .semantics {
+                    contentDescription = "New Record! Congratulations!"
+                },
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            ),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.EmojiEvents,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                modifier = Modifier.size(32.dp),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = "🏆 New Record!",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+/**
+ * Card displaying game statistics.
+ */
+@Composable
+private fun StatsCard(
+    correctAnswers: Int,
+    totalAttempts: Int,
+    accuracy: Float,
+    averageTime: Float,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "Statistics",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.semantics { heading() },
+            )
+
+            // Correct answers
+            StatRow(
+                icon = Icons.Filled.CheckCircle,
+                label = "Correct",
+                value = "$correctAnswers / $totalAttempts (${accuracy.toInt()}%)",
+                contentDescription = "$correctAnswers correct out of $totalAttempts attempts, ${accuracy.toInt()} percent accuracy",
+            )
+
+            // Average time
+            StatRow(
+                icon = Icons.Filled.Timer,
+                label = "Avg. Time",
+                value = String.format("%.1fs", averageTime),
+                contentDescription = "Average time per problem: ${String.format("%.1f", averageTime)} seconds",
+            )
+        }
+    }
+}
+
+/**
+ * A row displaying a statistic with icon, label, and value.
+ */
+@Composable
+private fun StatRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .semantics(mergeDescendants = true) {
+                    this.contentDescription = contentDescription
+                },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+/**
+ * Play Again and Home buttons.
+ */
+@Composable
+private fun ActionButtons(
+    onPlayAgain: () -> Unit,
+    onNavigateHome: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Play Again button (primary)
+        Button(
+            onClick = onPlayAgain,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .semantics {
+                        this.contentDescription = "Play again"
+                        role = Role.Button
+                    },
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Refresh,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Play Again",
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+
+        // Home button (secondary)
+        OutlinedButton(
+            onClick = onNavigateHome,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .semantics {
+                        this.contentDescription = "Go to home"
+                        role = Role.Button
+                    },
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Home,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Home",
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceResultsScreenPreview() {
+    KidsMathTutorAppTheme {
+        MathRaceResultsScreen(
+            finalScore = 21,
+            totalAttempts = 23,
+            isNewRecord = true,
+            accuracy = 91.3f,
+            averageTimePerProblem = 2.6f,
+            personalBest = 21,
+            userName = "Alex",
+            onPlayAgain = {},
+            onNavigateHome = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceResultsScreenNoRecordPreview() {
+    KidsMathTutorAppTheme {
+        MathRaceResultsScreen(
+            finalScore = 15,
+            totalAttempts = 18,
+            isNewRecord = false,
+            accuracy = 83.3f,
+            averageTimePerProblem = 3.2f,
+            personalBest = 21,
+            userName = null,
+            onPlayAgain = {},
+            onNavigateHome = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceResultsScreenDarkPreview() {
+    KidsMathTutorAppTheme(darkTheme = true) {
+        MathRaceResultsScreen(
+            finalScore = 25,
+            totalAttempts = 27,
+            isNewRecord = true,
+            accuracy = 92.6f,
+            averageTimePerProblem = 2.2f,
+            personalBest = 25,
+            userName = "Alex",
+            onPlayAgain = {},
+            onNavigateHome = {},
+        )
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceStartScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceStartScreen.kt
@@ -1,0 +1,220 @@
+package dev.hossain.mathtutor.ui.mathrace
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
+
+/**
+ * Start screen for Math Race game.
+ *
+ * Shows game title, description, personal best (if any), and a start button.
+ *
+ * @param personalBest Player's current high score (0 if none)
+ * @param userName Player's name for personalized greeting
+ * @param onStartGame Callback when start button is pressed
+ * @param onNavigateHome Callback to return to home/game selection
+ * @param modifier Optional modifier
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MathRaceStartScreen(
+    personalBest: Int,
+    userName: String?,
+    onStartGame: () -> Unit,
+    onNavigateHome: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Math Race") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onNavigateHome,
+                        modifier =
+                            Modifier.semantics {
+                                contentDescription = "Go back to home"
+                                role = Role.Button
+                            },
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+        modifier = modifier,
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            // Game title with emoji
+            Text(
+                text = "Math Race ⏱️",
+                style = MaterialTheme.typography.displayMedium,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+                modifier =
+                    Modifier.semantics {
+                        heading()
+                        contentDescription = "Math Race"
+                    },
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Game description
+            Text(
+                text = "Solve as many problems as you can in 60 seconds!",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Personal best display (only show if > 0)
+            if (personalBest > 0) {
+                PersonalBestDisplay(
+                    personalBest = personalBest,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Start button
+            Button(
+                onClick = onStartGame,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(64.dp)
+                        .semantics {
+                            contentDescription = "Start game"
+                            role = Role.Button
+                        },
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+            ) {
+                Text(
+                    text = "START GAME",
+                    style = MaterialTheme.typography.titleLarge,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(48.dp))
+        }
+    }
+}
+
+/**
+ * Displays the player's personal best score with a trophy icon.
+ */
+@Composable
+private fun PersonalBestDisplay(
+    personalBest: Int,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.EmojiEvents,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.tertiary,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Your Best: $personalBest",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.tertiary,
+            modifier =
+                Modifier.semantics {
+                    contentDescription = "Your personal best is $personalBest"
+                },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceStartScreenPreview() {
+    KidsMathTutorAppTheme {
+        MathRaceStartScreen(
+            personalBest = 18,
+            userName = "Alex",
+            onStartGame = {},
+            onNavigateHome = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceStartScreenNoBestPreview() {
+    KidsMathTutorAppTheme {
+        MathRaceStartScreen(
+            personalBest = 0,
+            userName = null,
+            onStartGame = {},
+            onNavigateHome = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MathRaceStartScreenDarkPreview() {
+    KidsMathTutorAppTheme(darkTheme = true) {
+        MathRaceStartScreen(
+            personalBest = 18,
+            userName = "Alex",
+            onStartGame = {},
+            onNavigateHome = {},
+        )
+    }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceUi.kt
@@ -1,0 +1,71 @@
+package dev.hossain.mathtutor.ui.mathrace
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.slack.circuit.codegen.annotations.CircuitInject
+import dev.zacsweers.metro.AppScope
+
+/**
+ * Main UI for [MathRaceScreen].
+ *
+ * Routes to the appropriate screen based on the current game state:
+ * - NotStarted → Start screen with game description and start button
+ * - Countdown → Animated 3-2-1-GO countdown
+ * - Playing → Game screen with timer, problem, and number pad
+ * - Finished → Results screen with score and stats
+ */
+@CircuitInject(MathRaceScreen::class, AppScope::class)
+@Composable
+fun MathRaceUi(
+    state: MathRaceScreen.State,
+    modifier: Modifier = Modifier,
+) {
+    when (val gameState = state.gameState) {
+        is MathRaceScreen.GameState.NotStarted -> {
+            MathRaceStartScreen(
+                personalBest = state.personalBest,
+                userName = state.userName,
+                onStartGame = { state.eventSink(MathRaceScreen.Event.StartGame) },
+                onNavigateHome = { state.eventSink(MathRaceScreen.Event.NavigateHome) },
+                modifier = modifier,
+            )
+        }
+
+        is MathRaceScreen.GameState.Countdown -> {
+            CountdownScreen(
+                countdownValue = gameState.countdownValue,
+                modifier = modifier,
+            )
+        }
+
+        is MathRaceScreen.GameState.Playing -> {
+            MathRaceGameScreen(
+                currentProblem = state.currentProblem,
+                currentAnswer = state.currentAnswer,
+                score = state.score,
+                timeRemaining = state.timeRemaining,
+                personalBest = state.personalBest,
+                lastAnswerCorrect = state.lastAnswerCorrect,
+                onNumberEntered = { digit -> state.eventSink(MathRaceScreen.Event.NumberEntered(digit)) },
+                onBackspace = { state.eventSink(MathRaceScreen.Event.Backspace) },
+                onCheckAnswer = { state.eventSink(MathRaceScreen.Event.CheckAnswer) },
+                modifier = modifier,
+            )
+        }
+
+        is MathRaceScreen.GameState.Finished -> {
+            MathRaceResultsScreen(
+                finalScore = gameState.finalScore,
+                totalAttempts = gameState.totalAttempts,
+                isNewRecord = gameState.isNewRecord,
+                accuracy = gameState.accuracy,
+                averageTimePerProblem = gameState.averageTimePerProblem,
+                personalBest = state.personalBest,
+                userName = state.userName,
+                onPlayAgain = { state.eventSink(MathRaceScreen.Event.PlayAgain) },
+                onNavigateHome = { state.eventSink(MathRaceScreen.Event.NavigateHome) },
+                modifier = modifier,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the visual UI for the Math Race mini-game as part of Phase 6-3 (#63).

## Changes

### MathRaceUi (Main Router)
- Main UI composable with `@CircuitInject` annotation
- Routes to appropriate screen based on GameState:
  - `NotStarted` → MathRaceStartScreen
  - `Countdown` → CountdownScreen  
  - `Playing` → MathRaceGameScreen
  - `Finished` → MathRaceResultsScreen

### MathRaceStartScreen
- Game title "Math Race ⏱️" with emoji
- Game description explaining the 60-second challenge
- Personal best display with trophy icon (only shown if > 0)
- Large "START GAME" button with Material 3 styling
- Back navigation to home screen

### CountdownScreen
- Large animated countdown numbers (3, 2, 1, GO!)
- Scale animation using `animateFloatAsState` (0.5 → 1.2 → 1.0)
- `displayLarge` typography for maximum visibility
- Tertiary color for "GO!" text
- `LiveRegion.Assertive` for TalkBack accessibility

### MathRaceGameScreen
- **Header row**: Timer and score displays side by side
- **Timer visual feedback**:
  - Color changes from primary to error when ≤10 seconds
  - Pulse animation (scale 1.0 → 1.1) when warning state
  - `animateColorAsState` for smooth color transitions
- **Problem display**: Card with spoken content description for accessibility
- **Answer field**: Reuses existing `AnswerField` component
- **Number pad**: Reuses existing `NumberPad` component
- **Action buttons**: Backspace (AutoMirrored) and Check buttons
- **Personal best footer** at bottom of screen

### MathRaceResultsScreen
- "Game Over! 🎉" animated title with slide-in animation
- **Final score** with pulse animation for new records
- **New Record badge**: Animated trophy with bounce animation
- **Stats card**: 
  - Correct answers / total attempts (accuracy %)
  - Average time per problem
- **Staggered entrance animations** for content sections
- "Play Again" (primary) and "Home" (outlined) buttons

### Animations
- Countdown scale animation
- Timer pulse when < 10 seconds
- Score pulse for new records
- Trophy bounce for new record badge
- Staggered fade-in/slide animations on results screen

### Material 3 Compliance
- ✅ All colors from `MaterialTheme.colorScheme`
- ✅ Typography from `MaterialTheme.typography`
- ✅ No hardcoded colors used

### Accessibility
- Content descriptions for all interactive elements
- `LiveRegion` for timer warnings
- Semantic headings for screen titles
- Role annotations for buttons

## Testing
- [x] `./gradlew formatKotlin` - Code formatted
- [x] `./gradlew assembleDebug` - Build successful
- [x] Preview composables included for all screens

## Related Issue
Closes #63