### PR TITLE
chore: Phase 6-6 polish - fix lint issues and update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced background music with "Swan Lake" music box version (`swan_lake_music_box.mp3`)
 
 ### Fixed
+- **Phase 6-6: Polish & Testing** - Code quality and test fixes (#66)
+  - Fixed Kotlin lint line-length violation in `GameSelectionPresenter.kt` Timber log statement
+  - Updated `CheckBadgeUnlocksUseCaseTest` to include `FakeGameRepository` for new game badge tests
+  - Updated `BadgeCategoryTest` to expect 6 categories (added GAMES)
+  - Updated `BadgeDefinitionsTest` to expect 19 badges (added 4 game badges)
+  - Updated `BadgeRepositoryImplTest` to expect 19 default badges
+
 - **Background Music Auto-Play Bug** - Music no longer plays automatically on app launch
   - Changed `musicEnabled` default from `true` to `false` in AudioServiceImpl
   - Users must explicitly enable background music via settings or home screen toggle

--- a/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionPresenter.kt
@@ -96,9 +96,13 @@ class GameSelectionPresenter
                 )
 
             Timber.d(
-                "GameSelection: Games - MathRace(unlocked=${gameInfoList[0].isUnlocked}, best=${gameInfoList[0].personalBest}, plays=${gameInfoList[0].totalPlays}), " +
-                    "MemoryMatch(unlocked=${gameInfoList[1].isUnlocked}, best=${gameInfoList[1].personalBest}, plays=${gameInfoList[1].totalPlays}), " +
-                    "NumberSequence(unlocked=${gameInfoList[2].isUnlocked}, best=${gameInfoList[2].personalBest}, plays=${gameInfoList[2].totalPlays})",
+                "GameSelection: Games - " +
+                    "MathRace(unlocked=${gameInfoList[0].isUnlocked}, " +
+                    "best=${gameInfoList[0].personalBest}, plays=${gameInfoList[0].totalPlays}), " +
+                    "MemoryMatch(unlocked=${gameInfoList[1].isUnlocked}, " +
+                    "best=${gameInfoList[1].personalBest}, plays=${gameInfoList[1].totalPlays}), " +
+                    "NumberSequence(unlocked=${gameInfoList[2].isUnlocked}, " +
+                    "best=${gameInfoList[2].personalBest}, plays=${gameInfoList[2].totalPlays})",
             )
 
             return GameSelectionScreen.State(

--- a/app/src/test/java/dev/hossain/mathtutor/data/repository/BadgeRepositoryImplTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/data/repository/BadgeRepositoryImplTest.kt
@@ -157,7 +157,7 @@ class BadgeRepositoryImplTest {
 
             assertEquals(1, fakeDao.insertBadgesCalls)
             assertNotNull(fakeDao.lastInsertedBadges)
-            assertEquals(15, fakeDao.lastInsertedBadges!!.size) // 15 default badges
+            assertEquals(19, fakeDao.lastInsertedBadges!!.size) // 19 default badges
         }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeCategoryTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeCategoryTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class BadgeCategoryTest {
     @Test
     fun `BadgeCategory has correct values`() {
-        assertEquals(5, BadgeCategory.entries.size)
+        assertEquals(6, BadgeCategory.entries.size)
     }
 
     @Test
@@ -16,5 +16,6 @@ class BadgeCategoryTest {
         assertEquals(BadgeCategory.OPERATION_MASTERY, BadgeCategory.valueOf("OPERATION_MASTERY"))
         assertEquals(BadgeCategory.SPEED_ACCURACY, BadgeCategory.valueOf("SPEED_ACCURACY"))
         assertEquals(BadgeCategory.STREAK, BadgeCategory.valueOf("STREAK"))
+        assertEquals(BadgeCategory.GAMES, BadgeCategory.valueOf("GAMES"))
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeDefinitionsTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeDefinitionsTest.kt
@@ -6,10 +6,10 @@ import org.junit.Test
 
 class BadgeDefinitionsTest {
     @Test
-    fun `getAllBadges returns 15 badges`() {
+    fun `getAllBadges returns 19 badges`() {
         val badges = BadgeDefinitions.getAllBadges()
 
-        assertEquals("Should have exactly 15 badges", 15, badges.size)
+        assertEquals("Should have exactly 19 badges", 19, badges.size)
     }
 
     @Test
@@ -29,12 +29,14 @@ class BadgeDefinitionsTest {
         val operationMastery = badges.filter { it.category == BadgeCategory.OPERATION_MASTERY }
         val speedAccuracy = badges.filter { it.category == BadgeCategory.SPEED_ACCURACY }
         val streak = badges.filter { it.category == BadgeCategory.STREAK }
+        val games = badges.filter { it.category == BadgeCategory.GAMES }
 
         assertEquals("Should have 3 Getting Started badges", 3, gettingStarted.size)
         assertEquals("Should have 4 Volume badges", 4, volume.size)
         assertEquals("Should have 3 Operation Mastery badges", 3, operationMastery.size)
         assertEquals("Should have 3 Speed & Accuracy badges", 3, speedAccuracy.size)
         assertEquals("Should have 2 Streak badges", 2, streak.size)
+        assertEquals("Should have 4 Games badges", 4, games.size)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/domain/usecase/CheckBadgeUnlocksUseCaseTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/usecase/CheckBadgeUnlocksUseCaseTest.kt
@@ -5,11 +5,15 @@ import dev.hossain.mathtutor.domain.model.Badge
 import dev.hossain.mathtutor.domain.model.BadgeCategory
 import dev.hossain.mathtutor.domain.model.BadgeRequirement
 import dev.hossain.mathtutor.domain.model.DailyStreak
+import dev.hossain.mathtutor.domain.model.Game
+import dev.hossain.mathtutor.domain.model.GameSession
+import dev.hossain.mathtutor.domain.model.GameStats
 import dev.hossain.mathtutor.domain.model.MathOperation
 import dev.hossain.mathtutor.domain.model.PracticeSession
 import dev.hossain.mathtutor.domain.model.SessionStats
 import dev.hossain.mathtutor.domain.repository.BadgeProgress
 import dev.hossain.mathtutor.domain.repository.BadgeRepository
+import dev.hossain.mathtutor.domain.repository.GameRepository
 import dev.hossain.mathtutor.domain.repository.SessionRepository
 import dev.hossain.mathtutor.domain.repository.StreakRepository
 import kotlinx.coroutines.flow.Flow
@@ -25,6 +29,7 @@ class CheckBadgeUnlocksUseCaseTest {
     private lateinit var fakeBadgeRepository: FakeBadgeRepository
     private lateinit var fakeSessionRepository: FakeSessionRepository
     private lateinit var fakeStreakRepository: FakeStreakRepository
+    private lateinit var fakeGameRepository: FakeGameRepository
     private lateinit var useCase: CheckBadgeUnlocksUseCase
 
     @Before
@@ -32,7 +37,14 @@ class CheckBadgeUnlocksUseCaseTest {
         fakeBadgeRepository = FakeBadgeRepository()
         fakeSessionRepository = FakeSessionRepository()
         fakeStreakRepository = FakeStreakRepository()
-        useCase = CheckBadgeUnlocksUseCase(fakeBadgeRepository, fakeSessionRepository, fakeStreakRepository)
+        fakeGameRepository = FakeGameRepository()
+        useCase =
+            CheckBadgeUnlocksUseCase(
+                fakeBadgeRepository,
+                fakeSessionRepository,
+                fakeStreakRepository,
+                fakeGameRepository,
+            )
     }
 
     @Test
@@ -375,5 +387,36 @@ class CheckBadgeUnlocksUseCaseTest {
         override suspend fun saveStreak(streak: DailyStreak) {
             currentStreak = streak
         }
+    }
+
+    /**
+     * Fake implementation of GameRepository for testing.
+     */
+    private class FakeGameRepository : GameRepository {
+        var totalGamesPlayed: Int = 0
+        var personalBest: Int = 0
+        var perfectGameCount: Int = 0
+
+        override suspend fun saveGameSession(session: GameSession): Long = 0
+
+        override fun getPersonalBest(game: Game): Flow<Int> = flowOf(personalBest)
+
+        override fun getBestSession(game: Game): Flow<GameSession?> = flowOf(null)
+
+        override fun getGameStats(game: Game): Flow<GameStats> = flowOf(GameStats(game, 0, 0, 0f, 0f, null))
+
+        override fun getTotalGamesPlayed(game: Game): Flow<Int> = flowOf(totalGamesPlayed)
+
+        override fun isGameUnlocked(game: Game): Flow<Boolean> = flowOf(true)
+
+        override fun getSessionsByGame(game: Game): Flow<List<GameSession>> = flowOf(emptyList())
+
+        override fun getRecentSessions(limit: Int): Flow<List<GameSession>> = flowOf(emptyList())
+
+        override fun getAllGameStats(): Flow<Map<Game, GameStats>> = flowOf(emptyMap())
+
+        override fun getPerfectGameCount(game: Game): Flow<Int> = flowOf(perfectGameCount)
+
+        override suspend fun clearAllSessions() {}
     }
 }


### PR DESCRIPTION
## Phase 6-6: Polish, Testing & Documentation (#66)

Completes Phase 6 with code quality improvements and test fixes.

### Code Quality Fixes

**Kotlin Lint Fix:**
- Fixed line-length violation in `GameSelectionPresenter.kt`
- Broke long Timber log statement into multiple concatenated lines

### Test Updates

Updated tests to account for the 4 new game badges added in Phase 6-5:

| Test File | Change |
|-----------|--------|
| `CheckBadgeUnlocksUseCaseTest` | Added `FakeGameRepository` for game badge support |
| `BadgeCategoryTest` | 5 → 6 categories (added GAMES) |
| `BadgeDefinitionsTest` | 15 → 19 badges (added 4 game badges) |
| `BadgeRepositoryImplTest` | 15 → 19 default badges |

### Verification

- ✅ `./gradlew formatKotlin` - No issues
- ✅ `./gradlew lintKotlin` - Passes
- ✅ `./gradlew lintDebug` - Passes  
- ✅ `./gradlew assembleDebug` - BUILD SUCCESSFUL
- ✅ `./gradlew test` - 629 tests passing
- ✅ AudioService has `playWarning()`, `playCountdown()`, `playGo()` methods

### Files Changed
- `GameSelectionPresenter.kt` - Fixed line length
- `CheckBadgeUnlocksUseCaseTest.kt` - Added FakeGameRepository
- `BadgeCategoryTest.kt` - Updated category count
- `BadgeDefinitionsTest.kt` - Updated badge count and added GAMES category assertion
- `BadgeRepositoryImplTest.kt` - Updated badge count
- `CHANGELOG.md` - Documented fixes

Closes #66