### PR TITLE
Release 1.5.0 - Phase 6: First Mini-Game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2025-12-19
+
 ### Added
 - **Phase 6-5: Game Badges System** - Badge rewards for mini-game achievements (#65)
   - **GAMES Badge Category** (`domain/model/BadgeCategory.kt`):
@@ -1107,5 +1109,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied proper system bars insets for edge-to-edge display on onboarding screen
 - Fixed onboarding navigation to properly navigate to MathPracticeScreen after completion
 
-[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.0.0...HEAD
+[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.5.0...HEAD
+[1.5.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.4.0...1.5.0
 [1.0.0]: https://github.com/hossain-khan/kids-math-pup-tutor/releases/tag/1.0.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "dev.hossain.mathtutor"
         minSdk = 28
         targetSdk = 36
-        versionCode = 5
-        versionName = "1.4.0"
+        versionCode = 6
+        versionName = "1.5.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.5.0 - Phase 6: First Mini-Game 🎮

### What's New

**Math Race Mini-Game**
- 60-second timed gameplay - solve as many problems as you can!
- 3-2-1-GO! countdown with audio/haptic feedback
- Personal best tracking and new record celebration
- Detailed results screen with accuracy and stats

**Games Hub**
- New "🎮 Play Games" button on home screen
- Game Selection screen showing available games
- Unlock system: Math Race unlocks at 50 problems solved
- Progress tracking for locked games

**Game Badges (4 New)**
- 🎮 Game Master - Play 10 games
- ⚡ Speed Demon - Score 20+ in Math Race
- 🏆 Racing Champion - Score 30+ in Math Race
- 💯 Perfect Race - Get 100% accuracy in a game

**Other Enhancements**
- Music toggle button on home screen
- New audio: countdown, go, and warning sounds
- Room database schema v5 for game sessions

### Version Changes
- Version: `1.4.0` → `1.5.0`
- versionCode: `5` → `6`

### Checklist
- [x] Version numbers updated
- [x] CHANGELOG.md updated with release date
- [x] All tests passing (629 tests)
- [x] Build successful