### PR TITLE
feat: Add grade selection from Settings screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Grade Selection from Settings** - Users can now change their grade level from the Settings screen (#XX)
+  - Navigate to full GradeSelectionScreen from Settings instead of using a dialog
+  - `GradeSelectionScreen` now accepts `isFromSettings` parameter for dual-mode operation
+  - When accessed from Settings: displays TopAppBar with back button, "Save" button instead of "Continue"
+  - Saves grade level and navigates back when used from Settings context
+  - Updated navigation documentation in `NAVIGATION.md`
+
 ## [1.5.0] - 2025-12-19
 
 ### Added

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -3,6 +3,7 @@ package dev.hossain.mathtutor.ui.onboarding
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -11,7 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -24,6 +25,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -197,8 +199,6 @@ fun GradeSelectionUi(
     state: GradeSelectionScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
-
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -216,6 +216,31 @@ fun GradeSelectionUi(
                 )
             }
         },
+        bottomBar = {
+            // Floating button at bottom for both onboarding and settings
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shadowElevation = 8.dp,
+                color = MaterialTheme.colorScheme.surface,
+            ) {
+                Button(
+                    onClick = { state.eventSink(GradeSelectionScreen.Event.ContinueClicked) },
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp, vertical = 16.dp)
+                            .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                            .height(56.dp),
+                    enabled = state.selectedGrade != null,
+                ) {
+                    Text(
+                        text = if (state.isFromSettings) "Save" else "Continue",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+        },
         contentWindowInsets = WindowInsets(0.dp),
     ) { paddingValues ->
         Column(
@@ -225,18 +250,18 @@ fun GradeSelectionUi(
                     .padding(paddingValues)
                     .then(
                         if (!state.isFromSettings) {
-                            // Onboarding: apply full system bars padding (no TopAppBar)
-                            Modifier.padding(systemBarsPadding)
+                            // Onboarding: apply top status bar padding (no TopAppBar)
+                            Modifier.padding(top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding())
                         } else {
-                            // From settings: only apply bottom navigation bar padding
-                            // (TopAppBar handles top padding)
-                            Modifier.padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                            Modifier
                         },
-                    ).padding(24.dp)
+                    ).padding(horizontal = 24.dp)
                     .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            Spacer(modifier = Modifier.height(8.dp))
+
             Text(
                 text = if (state.isFromSettings) "Select your grade level 🐶" else "Which grade are you in? 🐶",
                 style = MaterialTheme.typography.headlineMedium,
@@ -278,22 +303,6 @@ fun GradeSelectionUi(
             )
 
             Spacer(modifier = Modifier.height(16.dp))
-
-            // Continue/Save Button
-            Button(
-                onClick = { state.eventSink(GradeSelectionScreen.Event.ContinueClicked) },
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(56.dp),
-                enabled = state.selectedGrade != null,
-            ) {
-                Text(
-                    text = if (state.isFromSettings) "Save" else "Continue",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
@@ -224,9 +225,12 @@ fun GradeSelectionUi(
                     .padding(paddingValues)
                     .then(
                         if (!state.isFromSettings) {
+                            // Onboarding: apply full system bars padding (no TopAppBar)
                             Modifier.padding(systemBarsPadding)
                         } else {
-                            Modifier
+                            // From settings: only apply bottom navigation bar padding
+                            // (TopAppBar handles top padding)
+                            Modifier.padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
                         },
                     ).padding(24.dp)
                     .verticalScroll(rememberScrollState()),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +45,7 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.UserProfile
 import dev.hossain.mathtutor.domain.repository.UserProfileRepository
 import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
 import dev.zacsweers.metro.AppScope
@@ -52,6 +54,7 @@ import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import java.time.Instant
 
 /**
  * Circuit screen for grade selection during onboarding or from settings.
@@ -130,6 +133,9 @@ class GradeSelectionPresenter
             val scope = rememberCoroutineScope()
             var selectedGrade by remember { mutableStateOf<GradeLevel?>(null) }
 
+            // Collect current profile to check if it exists (for settings mode)
+            val currentProfile by userProfileRepository.getProfile().collectAsState(initial = null)
+
             return GradeSelectionScreen.State(
                 selectedGrade = selectedGrade,
                 isFromSettings = screen.isFromSettings,
@@ -145,7 +151,21 @@ class GradeSelectionPresenter
                             if (screen.isFromSettings) {
                                 // From settings: save grade and go back
                                 scope.launch {
-                                    userProfileRepository.updateGradeLevel(grade)
+                                    if (currentProfile != null) {
+                                        // Profile exists, just update the grade
+                                        userProfileRepository.updateGradeLevel(grade)
+                                    } else {
+                                        // No profile exists, create a new one
+                                        // This handles edge cases where profile wasn't created properly
+                                        userProfileRepository.saveProfile(
+                                            UserProfile(
+                                                name = null,
+                                                gradeLevel = grade,
+                                                createdAt = Instant.now(),
+                                                adaptiveDifficultyEnabled = true,
+                                            ),
+                                        )
+                                    }
                                     navigator.pop()
                                 }
                             } else {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -13,17 +13,23 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,29 +44,38 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.repository.UserProfileRepository
 import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
 /**
- * Circuit screen for grade selection during onboarding.
+ * Circuit screen for grade selection during onboarding or from settings.
  *
  * Allows users to select their grade level (K, 1, or 2) which determines
  * the difficulty and number ranges for math problems.
+ *
+ * @property isFromSettings When true, saves grade and navigates back instead of going to name entry.
+ *                          Used when accessing from Settings screen to change grade level.
  */
 @Parcelize
-data object GradeSelectionScreen : Screen {
+data class GradeSelectionScreen(
+    val isFromSettings: Boolean = false,
+) : Screen {
     /**
      * State for [GradeSelectionScreen].
      *
      * @property selectedGrade Currently selected grade level, null if none selected
+     * @property isFromSettings Whether this screen was opened from settings
      * @property eventSink Handler for screen events
      */
     data class State(
         val selectedGrade: GradeLevel?,
+        val isFromSettings: Boolean = false,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -79,31 +94,45 @@ data object GradeSelectionScreen : Screen {
          * User tapped Continue button (requires grade selection).
          */
         data object ContinueClicked : Event
+
+        /**
+         * User tapped back button.
+         */
+        data object BackClicked : Event
     }
 }
 
 /**
  * Presenter for [GradeSelectionScreen].
  *
- * Manages grade selection state and navigation to name entry screen.
+ * Manages grade selection state and navigation. Handles two modes:
+ * - Onboarding mode: Navigates to name entry screen after selection
+ * - Settings mode: Saves grade level and navigates back
  */
 @AssistedInject
 class GradeSelectionPresenter
     constructor(
+        @Assisted private val screen: GradeSelectionScreen,
         @Assisted private val navigator: Navigator,
+        private val userProfileRepository: UserProfileRepository,
     ) : Presenter<GradeSelectionScreen.State> {
         @CircuitInject(GradeSelectionScreen::class, AppScope::class)
         @AssistedFactory
         interface Factory {
-            fun create(navigator: Navigator): GradeSelectionPresenter
+            fun create(
+                screen: GradeSelectionScreen,
+                navigator: Navigator,
+            ): GradeSelectionPresenter
         }
 
         @Composable
         override fun present(): GradeSelectionScreen.State {
+            val scope = rememberCoroutineScope()
             var selectedGrade by remember { mutableStateOf<GradeLevel?>(null) }
 
             return GradeSelectionScreen.State(
                 selectedGrade = selectedGrade,
+                isFromSettings = screen.isFromSettings,
             ) { event ->
                 when (event) {
                     is GradeSelectionScreen.Event.GradeSelected -> {
@@ -112,9 +141,22 @@ class GradeSelectionPresenter
 
                     is GradeSelectionScreen.Event.ContinueClicked -> {
                         // Only navigate if grade is selected
-                        selectedGrade?.let {
-                            navigator.goTo(NameEntryScreen(gradeLevel = it))
+                        selectedGrade?.let { grade ->
+                            if (screen.isFromSettings) {
+                                // From settings: save grade and go back
+                                scope.launch {
+                                    userProfileRepository.updateGradeLevel(grade)
+                                    navigator.pop()
+                                }
+                            } else {
+                                // Onboarding: navigate to name entry
+                                navigator.goTo(NameEntryScreen(gradeLevel = grade))
+                            }
                         }
+                    }
+
+                    is GradeSelectionScreen.Event.BackClicked -> {
+                        navigator.pop()
                     }
                 }
             }
@@ -125,8 +167,10 @@ class GradeSelectionPresenter
  * UI for [GradeSelectionScreen].
  *
  * Displays three grade cards with descriptions and example problems.
+ * Shows a TopAppBar with back button when accessed from settings.
  */
 @CircuitInject(GradeSelectionScreen::class, AppScope::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GradeSelectionUi(
     state: GradeSelectionScreen.State,
@@ -136,6 +180,21 @@ fun GradeSelectionUi(
 
     Scaffold(
         modifier = modifier,
+        topBar = {
+            if (state.isFromSettings) {
+                TopAppBar(
+                    title = { Text("Change Grade") },
+                    navigationIcon = {
+                        IconButton(onClick = { state.eventSink(GradeSelectionScreen.Event.BackClicked) }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back",
+                            )
+                        }
+                    },
+                )
+            }
+        },
         contentWindowInsets = WindowInsets(0.dp),
     ) { paddingValues ->
         Column(
@@ -143,14 +202,19 @@ fun GradeSelectionUi(
                 Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(systemBarsPadding)
-                    .padding(24.dp)
+                    .then(
+                        if (!state.isFromSettings) {
+                            Modifier.padding(systemBarsPadding)
+                        } else {
+                            Modifier
+                        },
+                    ).padding(24.dp)
                     .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
-                text = "Which grade are you in? 🐶",
+                text = if (state.isFromSettings) "Select your grade level 🐶" else "Which grade are you in? 🐶",
                 style = MaterialTheme.typography.headlineMedium,
                 color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
@@ -191,7 +255,7 @@ fun GradeSelectionUi(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Continue Button
+            // Continue/Save Button
             Button(
                 onClick = { state.eventSink(GradeSelectionScreen.Event.ContinueClicked) },
                 modifier =
@@ -201,7 +265,7 @@ fun GradeSelectionUi(
                 enabled = state.selectedGrade != null,
             ) {
                 Text(
-                    text = "Continue",
+                    text = if (state.isFromSettings) "Save" else "Continue",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                 )

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/OnboardingScreen.kt
@@ -138,7 +138,7 @@ class OnboardingPresenter
                     -> {
                         coroutineScope.launch {
                             userPreferencesRepository.setOnboardingCompleted(true)
-                            navigator.goTo(GradeSelectionScreen)
+                            navigator.goTo(GradeSelectionScreen())
                         }
                     }
                 }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
@@ -11,6 +11,7 @@ import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.UserProfile
 import dev.hossain.mathtutor.domain.repository.UserProfileRepository
 import dev.hossain.mathtutor.ui.onboarding.GradeSelectionScreen
 import dev.zacsweers.metro.AppScope
@@ -79,7 +80,19 @@ class SettingsPresenter
                         Timber.d("SettingsScreen: Saving name - ${event.name}")
                         showNameDialog = false
                         scope.launch {
-                            userProfileRepository.updateName(event.name)
+                            if (profile != null) {
+                                userProfileRepository.updateName(event.name)
+                            } else {
+                                // No profile exists, create one with default grade
+                                userProfileRepository.saveProfile(
+                                    UserProfile(
+                                        name = event.name,
+                                        gradeLevel = GradeLevel.KINDERGARTEN,
+                                        createdAt = java.time.Instant.now(),
+                                        adaptiveDifficultyEnabled = true,
+                                    ),
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
@@ -12,6 +12,7 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import dev.hossain.mathtutor.domain.model.GradeLevel
 import dev.hossain.mathtutor.domain.repository.UserProfileRepository
+import dev.hossain.mathtutor.ui.onboarding.GradeSelectionScreen
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -63,8 +64,8 @@ class SettingsPresenter
                     }
 
                     is SettingsScreen.Event.ChangeGradeClicked -> {
-                        Timber.d("SettingsScreen: Change grade clicked")
-                        showGradeDialog = true
+                        Timber.d("SettingsScreen: Change grade clicked - navigating to GradeSelectionScreen")
+                        navigator.goTo(GradeSelectionScreen(isFromSettings = true))
                     }
 
                     is SettingsScreen.Event.ToggleAdaptiveDifficulty -> {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
@@ -173,7 +173,7 @@ private fun ProfileSection(
             // Grade level field
             ProfileField(
                 label = "Grade Level",
-                value = profile?.gradeLevel?.displayName ?: "Loading...",
+                value = profile?.gradeLevel?.displayName ?: "Not set",
                 onEditClick = onChangeGradeClick,
                 actionLabel = "Change",
             )

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
@@ -112,9 +112,9 @@ fun SettingsUi(
     }
 
     // Show dialogs when needed
-    if (state.showNameDialog && state.profile != null) {
+    if (state.showNameDialog) {
         NameEditDialog(
-            currentName = state.profile.name,
+            currentName = state.profile?.name,
             onDismiss = { state.eventSink(SettingsScreen.Event.CancelNameEdit) },
             onSave = { name -> state.eventSink(SettingsScreen.Event.SaveName(name)) },
         )

--- a/project-resources/tech-doc/NAVIGATION.md
+++ b/project-resources/tech-doc/NAVIGATION.md
@@ -13,7 +13,7 @@ The app contains **13 Circuit screens** organized by feature:
 | # | Screen | Location | Type | Description |
 |---|--------|----------|------|-------------|
 | 1 | `OnboardingScreen` | `ui/onboarding/` | `data object` | Welcome screen for new users |
-| 2 | `GradeSelectionScreen` | `ui/onboarding/` | `data object` | Grade level selection (K-2) |
+| 2 | `GradeSelectionScreen` | `ui/onboarding/` | `data class` | Grade level selection (K-2) |
 | 3 | `NameEntryScreen` | `ui/onboarding/` | `data class` | Child's name input |
 | 4 | `HomeScreen` | `ui/home/` | `data object` | Main hub with activity options |
 | 5 | `OperationSelectorScreen` | `ui/operationselector/` | `data object` | Math operation selection |
@@ -62,15 +62,15 @@ The app has two entry points defined in `MainActivity.kt`:
 │    │Operation │ │ Stats  │ │ Badges │ │Settings│ │    Game     │            │
 │    │ Selector │ │ Screen │ │ Screen │ │ Screen │ │  Selection  │            │
 │    └────┬─────┘ └────────┘ └────────┘ └───┬────┘ └──────┬──────┘            │
-│         │                                 │             │                   │
-│    ┌────┴────┐                          goTo          goTo                  │
-│    │         │                            │             │                   │
-│  goTo      goTo                           ▼             ▼                   │
-│    │         │                    ┌─────────────┐ ┌──────────┐              │
-│    ▼         ▼                    │AudioHaptic │ │ MathRace │              │
-│ ┌──────┐ ┌────────┐               │  Settings  │ │  Screen  │              │
-│ │ Math │ │ Stats  │               └─────────────┘ └──────────┘              │
-│ │Pract.│ │ Screen │                                                         │
+│         │                            ┌────┴────┐        │                   │
+│    ┌────┴────┐                       │         │      goTo                  │
+│    │         │                     goTo      goTo       │                   │
+│  goTo      goTo                      │         │        ▼                   │
+│    │         │                       ▼         ▼   ┌──────────┐             │
+│    ▼         ▼               ┌─────────────┐ ┌───────────┐│ MathRace │      │
+│ ┌──────┐ ┌────────┐          │AudioHaptic │ │   Grade   ││  Screen  │       │
+│ │ Math │ │ Stats  │          │  Settings  │ │ Selection │└──────────┘       │
+│ │Pract.│ │ Screen │          └─────────────┘ └───────────┘                  │
 │ └──┬───┘ └────────┘                                                         │
 │    │                                                                        │
 │  goTo                                                                       │
@@ -101,7 +101,7 @@ The app has two entry points defined in `MainActivity.kt`:
 | Screen | Navigated From | Method | Navigates To |
 |--------|---------------|--------|--------------|
 | `OnboardingScreen` | MainActivity (root) | Initial | `GradeSelectionScreen` |
-| `GradeSelectionScreen` | OnboardingScreen | `goTo` | `NameEntryScreen` |
+| `GradeSelectionScreen` | OnboardingScreen, SettingsScreen | `goTo` | `NameEntryScreen` (onboarding) or back (settings) |
 | `NameEntryScreen` | GradeSelectionScreen | `goTo` | `HomeScreen` |
 | `HomeScreen` | NameEntryScreen, ResultsScreen | `resetRoot` | Multiple screens |
 | `OperationSelectorScreen` | HomeScreen | `goTo` | `MathPracticeScreen`, `StatsScreen` |
@@ -109,7 +109,7 @@ The app has two entry points defined in `MainActivity.kt`:
 | `ResultsScreen` | MathPracticeScreen | `goTo` | `HomeScreen` |
 | `StatsScreen` | HomeScreen, OperationSelectorScreen | `goTo` | — |
 | `BadgesScreen` | HomeScreen | `goTo` | — |
-| `SettingsScreen` | HomeScreen | `goTo` | `AudioHapticSettingsScreen` |
+| `SettingsScreen` | HomeScreen | `goTo` | `AudioHapticSettingsScreen`, `GradeSelectionScreen` |
 | `AudioHapticSettingsScreen` | SettingsScreen | `goTo` | — |
 | `GameSelectionScreen` | HomeScreen | `goTo` | `MathRaceScreen` |
 | `MathRaceScreen` | GameSelectionScreen | `goTo` | — |


### PR DESCRIPTION
## Summary
Adds the ability to change grade level from the Settings screen, allowing users to update their grade without going through onboarding again.

## Changes

### New Features
- **Grade selection from Settings**: Users can now navigate to grade selection from Settings and update their grade level
- **Floating bottom button**: Continue/Save button now floats at the bottom in both onboarding and settings flows, remaining visible in landscape mode

### Bug Fixes
- **Profile creation**: Fixed issue where profile wasn't being created properly when only grade was saved (repository requires both `GRADE_KEY` and `CREATED_AT_KEY`)
- **Name editing**: Fixed name dialog not showing when profile was null in Settings
- **Edge-to-edge support**: Added proper navigation bar padding in GradeSelectionScreen

### Technical Details
- Changed `GradeSelectionScreen` from `data object` to `data class` with `isFromSettings: Boolean` parameter
- GradeSelectionPresenter now creates full `UserProfile` if none exists when saving from Settings
- SettingsPresenter creates full profile in SaveName handler if profile is null
- Bottom bar uses Surface with elevation for visual separation

## Testing
- [x] Grade selection works from onboarding flow
- [x] Grade selection works from Settings flow
- [x] Profile is created correctly when saving grade from Settings
- [x] Name can be edited when no profile exists
- [x] Floating button visible in landscape mode
- [x] Navigation bar doesn't overlap UI elements