### PR TITLE
Fix ANR caused by Timber.d calls in presenter composition bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Moved `navigator.pop()` call outside of coroutine block to prevent blocking UI thread
   - Database save now happens asynchronously without blocking navigation
   - User experiences immediate navigation response
+- **ANR when pressing back from My Stats screen** - Fixed Application Not Responding issue caused by excessive logging during recomposition
+  - Moved Timber.d() logging calls from composition body to `LaunchedEffect` blocks
+  - Logs now only execute when data changes, not on every recomposition
+  - Fixed same issue in `StatsPresenter`, `OperationSelectorPresenter`, and `GameSelectionPresenter`
 
 ## [1.5.0] - 2025-12-19
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/badges/BadgesPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/badges/BadgesPresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.badges
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -53,9 +54,13 @@ class BadgesPresenter
             // Group badges by category
             val badgesByCategory =
                 remember(allBadges) {
-                    Timber.d("Grouping ${allBadges.size} badges by category")
                     allBadges.groupBy { it.category }
                 }
+
+            // Log state changes in LaunchedEffect to avoid recomposition spam
+            LaunchedEffect(allBadges.size) {
+                Timber.d("Grouping ${allBadges.size} badges by category")
+            }
 
             return BadgesScreen.State(
                 badgesByCategory = badgesByCategory,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionPresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.games
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -46,9 +47,12 @@ class GameSelectionPresenter
             )
             val totalProblemsSolved = sessionStats.totalProblems
 
-            Timber.d(
-                "GameSelection: Total problems solved = $totalProblemsSolved",
-            )
+            // Log only when stats change (not on every recomposition)
+            LaunchedEffect(totalProblemsSolved) {
+                Timber.d(
+                    "GameSelection: Total problems solved = $totalProblemsSolved",
+                )
+            }
 
             // Collect personal bests and game stats for each game
             val mathRacePersonalBest by gameRepository
@@ -95,15 +99,18 @@ class GameSelectionPresenter
                     ),
                 )
 
-            Timber.d(
-                "GameSelection: Games - " +
-                    "MathRace(unlocked=${gameInfoList[0].isUnlocked}, " +
-                    "best=${gameInfoList[0].personalBest}, plays=${gameInfoList[0].totalPlays}), " +
-                    "MemoryMatch(unlocked=${gameInfoList[1].isUnlocked}, " +
-                    "best=${gameInfoList[1].personalBest}, plays=${gameInfoList[1].totalPlays}), " +
-                    "NumberSequence(unlocked=${gameInfoList[2].isUnlocked}, " +
-                    "best=${gameInfoList[2].personalBest}, plays=${gameInfoList[2].totalPlays})",
-            )
+            // Log only when game info changes (not on every recomposition)
+            LaunchedEffect(gameInfoList) {
+                Timber.d(
+                    "GameSelection: Games - " +
+                        "MathRace(unlocked=${gameInfoList[0].isUnlocked}, " +
+                        "best=${gameInfoList[0].personalBest}, plays=${gameInfoList[0].totalPlays}), " +
+                        "MemoryMatch(unlocked=${gameInfoList[1].isUnlocked}, " +
+                        "best=${gameInfoList[1].personalBest}, plays=${gameInfoList[1].totalPlays}), " +
+                        "NumberSequence(unlocked=${gameInfoList[2].isUnlocked}, " +
+                        "best=${gameInfoList[2].personalBest}, plays=${gameInfoList[2].totalPlays})",
+                )
+            }
 
             return GameSelectionScreen.State(
                 gameInfoList = gameInfoList,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/HomePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/HomePresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.home
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -56,29 +57,42 @@ class HomePresenter
 
             // Collect user profile
             val userProfile by userProfileRepository.getProfile().collectAsState(initial = null)
-            Timber.d(
-                "HomeScreen: User profile - name=${userProfile?.name}, grade=${userProfile?.gradeLevel}",
-            )
 
             // Collect streak data
             val streakData by streakRepository.getStreak().collectAsState(initial = null)
-            Timber.d(
-                "HomeScreen: Streak data - currentStreak=${streakData?.currentStreak}, lastPracticeDate=${streakData?.lastPracticeDate}",
-            )
 
             // Collect overall stats
             val overallStats by sessionRepository.getOverallStats().collectAsState(
                 initial = SessionStats.EMPTY,
-            )
-            Timber.d(
-                "HomeScreen: Overall stats - sessionCount=${overallStats.sessionCount}, totalProblems=${overallStats.totalProblems}, accuracy=${overallStats.accuracy}",
             )
 
             // Collect 3 most recently unlocked badges
             val recentBadges by badgeRepository.getRecentlyUnlockedBadges(limit = 3).collectAsState(
                 initial = emptyList(),
             )
-            Timber.d("HomeScreen: Recent badges count=${recentBadges.size}")
+
+            // Log state changes in LaunchedEffect to avoid recomposition spam
+            LaunchedEffect(userProfile?.name, userProfile?.gradeLevel) {
+                Timber.d(
+                    "HomeScreen: User profile - name=${userProfile?.name}, grade=${userProfile?.gradeLevel}",
+                )
+            }
+
+            LaunchedEffect(streakData?.currentStreak, streakData?.lastPracticeDate) {
+                Timber.d(
+                    "HomeScreen: Streak data - currentStreak=${streakData?.currentStreak}, lastPracticeDate=${streakData?.lastPracticeDate}",
+                )
+            }
+
+            LaunchedEffect(overallStats.sessionCount, overallStats.totalProblems) {
+                Timber.d(
+                    "HomeScreen: Overall stats - sessionCount=${overallStats.sessionCount}, totalProblems=${overallStats.totalProblems}, accuracy=${overallStats.accuracy}",
+                )
+            }
+
+            LaunchedEffect(recentBadges.size) {
+                Timber.d("HomeScreen: Recent badges count=${recentBadges.size}")
+            }
 
             return HomeScreen.State(
                 userName = userProfile?.name,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/operationselector/OperationSelectorPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/operationselector/OperationSelectorPresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.operationselector
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -41,7 +42,11 @@ class OperationSelectorPresenter
                 initial = dev.hossain.mathtutor.domain.model.SessionStats.EMPTY,
             )
             val hasSessionHistory = overallStats.sessionCount > 0
-            Timber.d("OperationSelector: Session history exists = $hasSessionHistory (sessionCount=${overallStats.sessionCount})")
+
+            // Log only when stats change (not on every recomposition)
+            LaunchedEffect(overallStats.sessionCount) {
+                Timber.d("OperationSelector: Session history exists = $hasSessionHistory (sessionCount=${overallStats.sessionCount})")
+            }
 
             return OperationSelectorScreen.State(
                 hasSessionHistory = hasSessionHistory,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/AudioHapticSettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/AudioHapticSettingsPresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.settings
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -49,10 +50,13 @@ class AudioHapticSettingsPresenter
             val highContrastEnabled by userPreferencesRepository.isHighContrastEnabled.collectAsState(initial = false)
             val largeTextEnabled by userPreferencesRepository.isLargeTextEnabled.collectAsState(initial = false)
 
-            Timber.d(
-                "[AudioHapticSettings] State - soundEffects=$soundEffectsEnabled, music=$backgroundMusicEnabled, " +
-                    "haptics=$hapticsEnabled, volume=$volume, highContrast=$highContrastEnabled, largeText=$largeTextEnabled",
-            )
+            // Log state changes in LaunchedEffect to avoid recomposition spam
+            LaunchedEffect(soundEffectsEnabled, backgroundMusicEnabled, hapticsEnabled, volume, highContrastEnabled, largeTextEnabled) {
+                Timber.d(
+                    "[AudioHapticSettings] State - soundEffects=$soundEffectsEnabled, music=$backgroundMusicEnabled, " +
+                        "haptics=$hapticsEnabled, volume=$volume, highContrast=$highContrastEnabled, largeText=$largeTextEnabled",
+                )
+            }
 
             return AudioHapticSettingsScreen.State(
                 soundEffectsEnabled = soundEffectsEnabled,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.settings
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,9 +46,13 @@ class SettingsPresenter
 
             // Collect user profile
             val profile by userProfileRepository.getProfile().collectAsState(initial = null)
-            Timber.d(
-                "SettingsScreen: Profile loaded - name=${profile?.name}, grade=${profile?.gradeLevel}, adaptive=${profile?.adaptiveDifficultyEnabled}",
-            )
+
+            // Log state changes in LaunchedEffect to avoid recomposition spam
+            LaunchedEffect(profile?.name, profile?.gradeLevel, profile?.adaptiveDifficultyEnabled) {
+                Timber.d(
+                    "SettingsScreen: Profile loaded - name=${profile?.name}, grade=${profile?.gradeLevel}, adaptive=${profile?.adaptiveDifficultyEnabled}",
+                )
+            }
 
             // Dialog visibility states
             var showNameDialog by remember { mutableStateOf(false) }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/stats/StatsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/stats/StatsPresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.stats
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -39,16 +40,11 @@ class StatsPresenter
             val overallStats by sessionRepository.getOverallStats().collectAsState(
                 initial = SessionStats.EMPTY,
             )
-            Timber.d(
-                "StatsScreen: Overall stats loaded - sessionCount=${overallStats.sessionCount}, " +
-                    "totalProblems=${overallStats.totalProblems}, accuracy=${overallStats.accuracy}",
-            )
 
             // Collect recent sessions (last 10)
             val recentSessions by sessionRepository.getRecentSessions(limit = 10).collectAsState(
                 initial = emptyList(),
             )
-            Timber.d("StatsScreen: Loaded ${recentSessions.size} recent sessions")
 
             // Collect statistics for each operation
             val additionStats by sessionRepository.getStatsByOperation(MathOperation.ADDITION).collectAsState(
@@ -57,6 +53,23 @@ class StatsPresenter
             val subtractionStats by sessionRepository.getStatsByOperation(MathOperation.SUBTRACTION).collectAsState(
                 initial = SessionStats.EMPTY,
             )
+
+            // Log stats only when they change (not on every recomposition)
+            LaunchedEffect(overallStats) {
+                Timber.d(
+                    "StatsScreen: Overall stats loaded - sessionCount=${overallStats.sessionCount}, " +
+                        "totalProblems=${overallStats.totalProblems}, accuracy=${overallStats.accuracy}",
+                )
+            }
+            LaunchedEffect(recentSessions.size) {
+                Timber.d("StatsScreen: Loaded ${recentSessions.size} recent sessions")
+            }
+            LaunchedEffect(additionStats, subtractionStats) {
+                Timber.d(
+                    "StatsScreen: Operation stats - Addition(sessions=${additionStats.sessionCount}), " +
+                        "Subtraction(sessions=${subtractionStats.sessionCount})",
+                )
+            }
 
             // Build operation stats map, only including operations with sessions
             val operationStats =
@@ -68,10 +81,6 @@ class StatsPresenter
                         put(MathOperation.SUBTRACTION, subtractionStats)
                     }
                 }
-            Timber.d(
-                "StatsScreen: Operation stats - Addition(sessions=${additionStats.sessionCount}), " +
-                    "Subtraction(sessions=${subtractionStats.sessionCount})",
-            )
 
             return StatsScreen.State(
                 overallStats = overallStats,


### PR DESCRIPTION
## Summary

Fixes ANR (Application Not Responding) issue caused by `Timber.d()` logging calls executing on every recomposition in Circuit presenters. This caused 97% CPU usage on the main thread during navigation transitions.

## Root Cause

`Timber.d()` calls placed directly in the `present()` composition body execute on **every recomposition**. During rapid recomposition (e.g., navigation transitions), this creates excessive logging that blocks the main thread.

## Solution

Moved all `Timber.d()` calls from composition bodies to `LaunchedEffect` blocks with appropriate state keys. This ensures logging only occurs when the relevant state actually changes.

## Files Changed

| Presenter | Issues Fixed |
|-----------|--------------|
| `StatsPresenter.kt` | 4 Timber.d calls (overall stats, recent sessions, addition/subtraction stats) |
| `OperationSelectorPresenter.kt` | 1 Timber.d call (session count) |
| `GameSelectionPresenter.kt` | 2 Timber.d calls (total problems solved, game info) |
| `HomePresenter.kt` | 4 Timber.d calls (profile, streak, stats, badges) |
| `SettingsPresenter.kt` | 1 Timber.d call (profile loading) |
| `AudioHapticSettingsPresenter.kt` | 1 Timber.d call (settings state) |
| `BadgesPresenter.kt` | 1 Timber.d call (badge grouping from remember block) |

## Pattern Applied

```kotlin
// BEFORE (problematic):
val data by flow.collectAsState(initial)
Timber.d("Data loaded: $data")  // Executes EVERY recomposition

// AFTER (fixed):
val data by flow.collectAsState(initial)
LaunchedEffect(data) {
    Timber.d("Data loaded: $data")  // Only executes when data changes
}
```

## Testing

- [x] Build succeeds
- [x] Manual testing: No ANR when navigating back from Stats screen
- [x] Verified all presenters follow the correct pattern