### PR TITLE
Fix Truth assertion syntax in all test files

### DIFF
--- a/app/src/test/java/dev/hossain/mathtutor/Phase3EdgeCasesTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/Phase3EdgeCasesTest.kt
@@ -149,8 +149,8 @@ class Phase3EdgeCasesTest {
         val additionMet = additionStats.totalProblems >= 50
         val subtractionMet = subtractionStats.totalProblems >= 50
 
-        assertThat("Addition badge should unlock", additionMet).isTrue()
-        assertThat("Subtraction badge should unlock", subtractionMet).isTrue()
+        assertThat(additionMet).isTrue()
+        assertThat(subtractionMet).isTrue()
     }
 
     // ============================================================
@@ -171,11 +171,11 @@ class Phase3EdgeCasesTest {
         // Second practice same day
         val secondPractice = streak.updateStreak(today)
 
-        assertThat(streak.currentStreak, secondPractice.currentStreak).isEqualTo("Current streak should not change")
-        assertThat(streak.longestStreak, secondPractice.longestStreak).isEqualTo("Longest streak should not change")
-        assertThat(streak.totalDaysPracticed, secondPractice.totalDaysPracticed).isEqualTo("Total days practiced should not change")
-        assertThat(streak.lastPracticeDate, secondPractice.lastPracticeDate).isEqualTo("Last practice date should remain same")
-        assertThat(streak, secondPractice).isEqualTo("Streak should be identical")
+        assertThat(streak.currentStreak).isEqualTo(secondPractice.currentStreak)
+        assertThat(streak.longestStreak).isEqualTo(secondPractice.longestStreak)
+        assertThat(streak.totalDaysPracticed).isEqualTo(secondPractice.totalDaysPracticed)
+        assertThat(streak.lastPracticeDate).isEqualTo(secondPractice.lastPracticeDate)
+        assertThat(secondPractice).isEqualTo(streak)
     }
 
     @Test
@@ -192,7 +192,7 @@ class Phase3EdgeCasesTest {
         // Simulate 5 practice sessions same day
         repeat(5) {
             val updatedStreak = streak.updateStreak(today)
-            assertThat(streak, updatedStreak).isEqualTo("Streak should not change on same-day practice")
+            assertThat(updatedStreak).isEqualTo(streak)
             streak = updatedStreak
         }
 
@@ -365,16 +365,13 @@ class Phase3EdgeCasesTest {
             )
 
         assertThat(categories.size).isEqualTo(5)
-        assertThat(
-            "All badge categories should be present",
-            categories.containsAll(
-                setOf(
-                    BadgeCategory.GETTING_STARTED,
-                    BadgeCategory.VOLUME,
-                    BadgeCategory.OPERATION_MASTERY,
-                    BadgeCategory.SPEED_ACCURACY,
-                    BadgeCategory.STREAK,
-                ).isTrue(),
+        assertThat(categories).containsExactlyElementsIn(
+            setOf(
+                BadgeCategory.GETTING_STARTED,
+                BadgeCategory.VOLUME,
+                BadgeCategory.OPERATION_MASTERY,
+                BadgeCategory.SPEED_ACCURACY,
+                BadgeCategory.STREAK,
             ),
         )
     }
@@ -391,8 +388,8 @@ class Phase3EdgeCasesTest {
             )
 
         volumeBadges.forEachIndexed { index, req ->
-            assertThat("Badge $index should have positive count", req.count > 0).isTrue()
-            assertThat("Badge $index should be achievable", req.count <= 1000).isTrue()
+            assertThat(req.count > 0).isTrue()
+            assertThat(req.count <= 1000).isTrue()
         }
 
         val streakBadges =
@@ -402,8 +399,8 @@ class Phase3EdgeCasesTest {
             )
 
         streakBadges.forEach { req ->
-            assertThat("Streak should be positive", req.days > 0).isTrue()
-            assertThat("Streak should be achievable", req.days <= 30).isTrue()
+            assertThat(req.days > 0).isTrue()
+            assertThat(req.days <= 30).isTrue()
         }
     }
 
@@ -418,7 +415,7 @@ class Phase3EdgeCasesTest {
 
         // Exactly 50 problems should unlock badge
         val meetsRequirement = stats.totalProblems >= 50
-        assertThat("Exactly meeting requirement should unlock badge", meetsRequirement).isTrue()
+        assertThat(meetsRequirement).isTrue()
     }
 
     @Test
@@ -428,7 +425,7 @@ class Phase3EdgeCasesTest {
 
         // 49 problems should NOT unlock badge
         val meetsRequirement = stats.totalProblems >= 50
-        assertThat("One less than requirement should not unlock badge", meetsRequirement).isFalse()
+        assertThat(meetsRequirement).isFalse()
     }
 
     @Test
@@ -438,7 +435,7 @@ class Phase3EdgeCasesTest {
         val requirement = BadgeRequirement.SessionAccuracy(90f, 1)
 
         val meetsRequirement = stats.accuracy >= 90f && stats.sessionCount >= 1
-        assertThat("Exactly 90% accuracy should unlock badge", meetsRequirement).isTrue()
+        assertThat(meetsRequirement).isTrue()
     }
 
     @Test
@@ -453,7 +450,7 @@ class Phase3EdgeCasesTest {
         val requirement = BadgeRequirement.DailyStreak(7)
 
         val meetsRequirement = streak.currentStreak >= 7
-        assertThat("Exactly 7-day streak should unlock badge", meetsRequirement).isTrue()
+        assertThat(meetsRequirement).isTrue()
     }
 
     @Test
@@ -470,7 +467,7 @@ class Phase3EdgeCasesTest {
             )
 
         // Streak is at risk (practiced yesterday, not today yet)
-        assertThat("Streak should be alive", streak.isStreakAlive(today)).isTrue()
+        assertThat(streak.isStreakAlive(today)).isTrue()
 
         // Practicing today saves it
         val saved = streak.updateStreak(today)
@@ -484,8 +481,8 @@ class Phase3EdgeCasesTest {
         val problemCountBadge = BadgeRequirement.ProblemCount(1)
         val accuracyBadge = BadgeRequirement.SessionAccuracy(50f, 1)
 
-        assertThat("Zero problems should not unlock badge", stats.totalProblems >= 1).isFalse()
-        assertThat("No sessions should not unlock accuracy badge", stats.sessionCount >= 1).isFalse()
+        assertThat(stats.totalProblems >= 1).isFalse()
+        assertThat(stats.sessionCount >= 1).isFalse()
     }
 
     // ============================================================

--- a/app/src/test/java/dev/hossain/mathtutor/data/mapper/BadgeMapperTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/data/mapper/BadgeMapperTest.kt
@@ -32,7 +32,7 @@ class BadgeMapperTest {
         assertThat(badge.icon).isEqualTo("🎯")
         assertThat(badge.category).isEqualTo(BadgeCategory.GETTING_STARTED)
         assert(badge.requirement is BadgeRequirement.ProblemCount)
-        assertThat((badge.requirement as BadgeRequirement.ProblemCount).isEqualTo(10).count)
+        assertThat((badge.requirement as BadgeRequirement.ProblemCount).count).isEqualTo(10)
         assertThat(badge.unlockedAt).isNull()
     }
 
@@ -75,7 +75,7 @@ class BadgeMapperTest {
         val badge = BadgeMapper.toDomain(entity)
 
         assert(badge.requirement is BadgeRequirement.ConsecutiveCorrect)
-        assertThat((badge.requirement as BadgeRequirement.ConsecutiveCorrect).isEqualTo(5).count)
+        assertThat((badge.requirement as BadgeRequirement.ConsecutiveCorrect).count).isEqualTo(5)
     }
 
     @Test
@@ -117,7 +117,7 @@ class BadgeMapperTest {
         val badge = BadgeMapper.toDomain(entity)
 
         assert(badge.requirement is BadgeRequirement.DailyStreak)
-        assertThat((badge.requirement as BadgeRequirement.DailyStreak).isEqualTo(7).days)
+        assertThat((badge.requirement as BadgeRequirement.DailyStreak).days).isEqualTo(7)
     }
 
     @Test
@@ -137,7 +137,7 @@ class BadgeMapperTest {
         val badge = BadgeMapper.toDomain(entity)
 
         assert(badge.requirement is BadgeRequirement.ProblemSpeed)
-        assertThat((badge.requirement as BadgeRequirement.ProblemSpeed).isEqualTo(3).maxSeconds)
+        assertThat((badge.requirement as BadgeRequirement.ProblemSpeed).maxSeconds).isEqualTo(3)
     }
 
     @Test
@@ -157,7 +157,7 @@ class BadgeMapperTest {
         val badge = BadgeMapper.toDomain(entity)
 
         assert(badge.requirement is BadgeRequirement.MixedSessions)
-        assertThat((badge.requirement as BadgeRequirement.MixedSessions).isEqualTo(10).count)
+        assertThat((badge.requirement as BadgeRequirement.MixedSessions).count).isEqualTo(10)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/data/repository/UserProfileRepositoryImplTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/data/repository/UserProfileRepositoryImplTest.kt
@@ -97,7 +97,7 @@ class UserProfileRepositoryImplTest {
             assertThat(retrievedProfile).isNotNull()
             assertThat(retrievedProfile?.name).isEqualTo("Test User")
             assertThat(retrievedProfile?.gradeLevel).isEqualTo(GradeLevel.GRADE_1)
-            assertThat(retrievedProfile?.createdAt?.toEpochMilli().isEqualTo(now.toEpochMilli()))
+            assertThat(retrievedProfile?.createdAt?.toEpochMilli()).isEqualTo(now.toEpochMilli())
             assertThat(retrievedProfile?.adaptiveDifficultyEnabled ?: false).isTrue()
         }
 
@@ -143,7 +143,7 @@ class UserProfileRepositoryImplTest {
             assertThat(retrievedProfile).isNotNull()
             assertThat(retrievedProfile?.name).isEqualTo("Test User")
             assertThat(retrievedProfile?.gradeLevel).isEqualTo(GradeLevel.GRADE_2)
-            assertThat(retrievedProfile?.createdAt?.toEpochMilli().isEqualTo(now.toEpochMilli()))
+            assertThat(retrievedProfile?.createdAt?.toEpochMilli()).isEqualTo(now.toEpochMilli())
             assertThat(retrievedProfile?.adaptiveDifficultyEnabled ?: false).isTrue()
         }
 
@@ -167,7 +167,7 @@ class UserProfileRepositoryImplTest {
             assertThat(retrievedProfile).isNotNull()
             assertThat(retrievedProfile?.name).isEqualTo("New Name")
             assertThat(retrievedProfile?.gradeLevel).isEqualTo(GradeLevel.GRADE_1)
-            assertThat(retrievedProfile?.createdAt?.toEpochMilli().isEqualTo(now.toEpochMilli()))
+            assertThat(retrievedProfile?.createdAt?.toEpochMilli()).isEqualTo(now.toEpochMilli())
             assertThat(retrievedProfile?.adaptiveDifficultyEnabled ?: false).isTrue()
         }
 
@@ -256,29 +256,26 @@ class UserProfileRepositoryImplTest {
             assertThat(
                 repository
                     .getProfile()
-                    .isEqualTo(GradeLevel.KINDERGARTEN)
                     .first()
                     ?.gradeLevel,
-            )
+            ).isEqualTo(GradeLevel.KINDERGARTEN)
 
             // Test Grade 1
             repository.updateGradeLevel(GradeLevel.GRADE_1)
             assertThat(
                 repository
                     .getProfile()
-                    .isEqualTo(GradeLevel.GRADE_1)
                     .first()
                     ?.gradeLevel,
-            )
+            ).isEqualTo(GradeLevel.GRADE_1)
 
             // Test Grade 2
             repository.updateGradeLevel(GradeLevel.GRADE_2)
             assertThat(
                 repository
                     .getProfile()
-                    .isEqualTo(GradeLevel.GRADE_2)
                     .first()
                     ?.gradeLevel,
-            )
+            ).isEqualTo(GradeLevel.GRADE_2)
         }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/generator/AdaptiveProblemGeneratorTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/generator/AdaptiveProblemGeneratorTest.kt
@@ -163,19 +163,19 @@ class AdaptiveProblemGeneratorTest {
     @Test
     fun `getNextGradeLevel returns correct next level`() {
         assertThat(
-            adaptiveProblemGenerator.getNextGradeLevel(GradeLevel.KINDERGARTEN).isEqualTo(GradeLevel.GRADE_1),
-        )
-        assertThat(adaptiveProblemGenerator.getNextGradeLevel(GradeLevel.GRADE_1).isEqualTo(GradeLevel.GRADE_2))
-        assertThat(adaptiveProblemGenerator.getNextGradeLevel(GradeLevel.GRADE_2).isEqualTo(GradeLevel.GRADE_2)) // Max
+            adaptiveProblemGenerator.getNextGradeLevel(GradeLevel.KINDERGARTEN),
+        ).isEqualTo(GradeLevel.GRADE_1)
+        assertThat(adaptiveProblemGenerator.getNextGradeLevel(GradeLevel.GRADE_1)).isEqualTo(GradeLevel.GRADE_2)
+        assertThat(adaptiveProblemGenerator.getNextGradeLevel(GradeLevel.GRADE_2)).isEqualTo(GradeLevel.GRADE_2) // Max
     }
 
     @Test
     fun `getPreviousGradeLevel returns correct previous level`() {
         assertThat(
-            adaptiveProblemGenerator.getPreviousGradeLevel(GradeLevel.KINDERGARTEN).isEqualTo(GradeLevel.KINDERGARTEN),
-        ) // Min
-        assertThat(adaptiveProblemGenerator.getPreviousGradeLevel(GradeLevel.GRADE_1).isEqualTo(GradeLevel.KINDERGARTEN))
-        assertThat(adaptiveProblemGenerator.getPreviousGradeLevel(GradeLevel.GRADE_2).isEqualTo(GradeLevel.GRADE_1))
+            adaptiveProblemGenerator.getPreviousGradeLevel(GradeLevel.KINDERGARTEN),
+        ).isEqualTo(GradeLevel.KINDERGARTEN) // Min
+        assertThat(adaptiveProblemGenerator.getPreviousGradeLevel(GradeLevel.GRADE_1)).isEqualTo(GradeLevel.KINDERGARTEN)
+        assertThat(adaptiveProblemGenerator.getPreviousGradeLevel(GradeLevel.GRADE_2)).isEqualTo(GradeLevel.GRADE_1)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/domain/generator/GradeAwareProblemGeneratorTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/generator/GradeAwareProblemGeneratorTest.kt
@@ -30,7 +30,7 @@ class GradeAwareProblemGeneratorTest {
     fun `generated problems have unique IDs`() {
         val problems = generator.generateProblems(20, MathOperation.ADDITION, GradeLevel.GRADE_1)
         val ids = problems.map { it.id }.toSet()
-        assertThat(problems.size, ids.size).isEqualTo("All problem IDs should be unique")
+        assertThat(problems.size).isEqualTo(ids.size)
     }
 
     // ==================== Kindergarten Addition Tests ====================
@@ -40,8 +40,8 @@ class GradeAwareProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.ADDITION, GradeLevel.KINDERGARTEN)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-10, got: ${problem.num1}", problem.num1 in 1..10).isTrue()
-            assertThat("num2 should be 1-10, got: ${problem.num2}", problem.num2 in 1..10).isTrue()
+            assertThat(problem.num1 in 1..10).isTrue()
+            assertThat(problem.num2 in 1..10).isTrue()
         }
     }
 
@@ -51,7 +51,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should be 2-18, got: ${problem.correctAnswer} from ${problem.num1} + ${problem.num2}",
                 problem.correctAnswer in 2..18,
             ).isTrue()
         }
@@ -63,10 +62,7 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 + problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} + ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -77,8 +73,8 @@ class GradeAwareProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.SUBTRACTION, GradeLevel.KINDERGARTEN)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-10, got: ${problem.num1}", problem.num1 in 1..10).isTrue()
-            assertThat("num2 should be 1-10, got: ${problem.num2}", problem.num2 in 1..10).isTrue()
+            assertThat(problem.num1 in 1..10).isTrue()
+            assertThat(problem.num2 in 1..10).isTrue()
         }
     }
 
@@ -88,7 +84,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should be 0-9, got: ${problem.correctAnswer} from ${problem.num1} - ${problem.num2}",
                 problem.correctAnswer in 0..9,
             ).isTrue()
         }
@@ -100,11 +95,9 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should not be negative: ${problem.num1} - ${problem.num2} = ${problem.correctAnswer}",
                 problem.correctAnswer >= 0,
             ).isTrue()
             assertThat(
-                "First number should be >= second number: ${problem.num1} >= ${problem.num2}",
                 problem.num1 >= problem.num2,
             ).isTrue()
         }
@@ -116,10 +109,7 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 - problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} - ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -131,10 +121,10 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             // Should be addition problems with K ranges
-            assertThat(MathOperation.ADDITION, problem.operation).isEqualTo("Should fall back to ADDITION")
-            assertThat("num1 should be 1-10", problem.num1 in 1..10).isTrue()
-            assertThat("num2 should be 1-10", problem.num2 in 1..10).isTrue()
-            assertThat(problem.num1 + problem.num2, problem.correctAnswer).isEqualTo("Should have correct addition answer")
+            assertThat(MathOperation.ADDITION).isEqualTo(problem.operation)
+            assertThat(problem.num1 in 1..10).isTrue()
+            assertThat(problem.num2 in 1..10).isTrue()
+            assertThat(problem.num1 + problem.num2).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -144,10 +134,10 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             // Should be subtraction problems with K ranges
-            assertThat(MathOperation.SUBTRACTION, problem.operation).isEqualTo("Should fall back to SUBTRACTION")
-            assertThat("num1 should be 1-10", problem.num1 in 1..10).isTrue()
-            assertThat("num2 should be 1-10", problem.num2 in 1..10).isTrue()
-            assertThat("Should not produce negative", problem.correctAnswer >= 0).isTrue()
+            assertThat(MathOperation.SUBTRACTION).isEqualTo(problem.operation)
+            assertThat(problem.num1 in 1..10).isTrue()
+            assertThat(problem.num2 in 1..10).isTrue()
+            assertThat(problem.correctAnswer >= 0).isTrue()
         }
     }
 
@@ -158,8 +148,8 @@ class GradeAwareProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.ADDITION, GradeLevel.GRADE_1)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-20, got: ${problem.num1}", problem.num1 in 1..20).isTrue()
-            assertThat("num2 should be 1-20, got: ${problem.num2}", problem.num2 in 1..20).isTrue()
+            assertThat(problem.num1 in 1..20).isTrue()
+            assertThat(problem.num2 in 1..20).isTrue()
         }
     }
 
@@ -169,7 +159,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should be 2-40, got: ${problem.correctAnswer} from ${problem.num1} + ${problem.num2}",
                 problem.correctAnswer in 2..40,
             ).isTrue()
         }
@@ -181,10 +170,7 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 + problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} + ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -195,8 +181,8 @@ class GradeAwareProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.SUBTRACTION, GradeLevel.GRADE_1)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-20, got: ${problem.num1}", problem.num1 in 1..20).isTrue()
-            assertThat("num2 should be 1-20, got: ${problem.num2}", problem.num2 in 1..20).isTrue()
+            assertThat(problem.num1 in 1..20).isTrue()
+            assertThat(problem.num2 in 1..20).isTrue()
         }
     }
 
@@ -206,7 +192,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should be 0-19, got: ${problem.correctAnswer} from ${problem.num1} - ${problem.num2}",
                 problem.correctAnswer in 0..19,
             ).isTrue()
         }
@@ -218,7 +203,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should not be negative: ${problem.num1} - ${problem.num2} = ${problem.correctAnswer}",
                 problem.correctAnswer >= 0,
             ).isTrue()
         }
@@ -233,7 +217,6 @@ class GradeAwareProblemGeneratorTest {
         val allowedMultipliers = setOf(2, 5, 10)
         problems.forEach { problem ->
             assertThat(
-                "Second number should be 2, 5, or 10, got: ${problem.num2}",
                 problem.num2 in allowedMultipliers,
             ).isTrue()
         }
@@ -245,7 +228,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "First operand should be 1-10, got: ${problem.num1}",
                 problem.num1 in 1..10,
             ).isTrue()
         }
@@ -257,10 +239,7 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 * problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} × ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -272,10 +251,10 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             // Should be subtraction problems with Grade 1 ranges
-            assertThat(MathOperation.SUBTRACTION, problem.operation).isEqualTo("Should fall back to SUBTRACTION")
-            assertThat("num1 should be 1-20", problem.num1 in 1..20).isTrue()
-            assertThat("num2 should be 1-20", problem.num2 in 1..20).isTrue()
-            assertThat("Should not produce negative", problem.correctAnswer >= 0).isTrue()
+            assertThat(MathOperation.SUBTRACTION).isEqualTo(problem.operation)
+            assertThat(problem.num1 in 1..20).isTrue()
+            assertThat(problem.num2 in 1..20).isTrue()
+            assertThat(problem.correctAnswer >= 0).isTrue()
         }
     }
 
@@ -286,8 +265,8 @@ class GradeAwareProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.ADDITION, GradeLevel.GRADE_2)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-100, got: ${problem.num1}", problem.num1 in 1..100).isTrue()
-            assertThat("num2 should be 1-100, got: ${problem.num2}", problem.num2 in 1..100).isTrue()
+            assertThat(problem.num1 in 1..100).isTrue()
+            assertThat(problem.num2 in 1..100).isTrue()
         }
     }
 
@@ -300,12 +279,12 @@ class GradeAwareProblemGeneratorTest {
         val num2Values = problems.map { it.num2 }
 
         // At least some numbers should be > 50
-        assertThat("Should have some num1 > 50", num1Values.any { it > 50 }).isTrue()
-        assertThat("Should have some num2 > 50", num2Values.any { it > 50 }).isTrue()
+        assertThat(num1Values.any { it > 50 }).isTrue()
+        assertThat(num2Values.any { it > 50 }).isTrue()
 
         // Should have variety (at least 30 different values out of 200 problems)
-        assertThat("Should have variety in num1", num1Values.toSet().isTrue().size >= 30)
-        assertThat("Should have variety in num2", num2Values.toSet().isTrue().size >= 30)
+        assertThat(num1Values.toSet().size >= 30).isTrue()
+        assertThat(num2Values.toSet().size >= 30).isTrue()
     }
 
     @Test
@@ -314,10 +293,7 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 + problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} + ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -328,8 +304,8 @@ class GradeAwareProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.SUBTRACTION, GradeLevel.GRADE_2)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-100, got: ${problem.num1}", problem.num1 in 1..100).isTrue()
-            assertThat("num2 should be 1-100, got: ${problem.num2}", problem.num2 in 1..100).isTrue()
+            assertThat(problem.num1 in 1..100).isTrue()
+            assertThat(problem.num2 in 1..100).isTrue()
         }
     }
 
@@ -339,7 +315,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should not be negative: ${problem.num1} - ${problem.num2} = ${problem.correctAnswer}",
                 problem.correctAnswer >= 0,
             ).isTrue()
         }
@@ -351,10 +326,7 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 - problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} - ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -366,7 +338,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Multiplier should be 2-10, got: ${problem.num2}",
                 problem.num2 in 2..10,
             ).isTrue()
         }
@@ -378,7 +349,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "First operand should be 1-12, got: ${problem.num1}",
                 problem.num1 in 1..12,
             ).isTrue()
         }
@@ -390,10 +360,7 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 * problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} × ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -405,7 +372,6 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Divisor should be 2-10, got: ${problem.num2}",
                 problem.num2 in 2..10,
             ).isTrue()
         }
@@ -417,10 +383,7 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val remainder = problem.num1 % problem.num2
-            assertThat(
-                0,
-                remainder,
-            ).isEqualTo("Division should have no remainder: ${problem.num1} ÷ ${problem.num2}")
+            assertThat(0).isEqualTo(remainder)
         }
     }
 
@@ -430,15 +393,9 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 / problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} ÷ ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
             // Also verify the multiplication fact
-            assertThat(
-                problem.num1,
-                problem.correctAnswer * problem.num2,
-            ).isEqualTo("Quotient × Divisor should equal Dividend")
+            assertThat(problem.num1).isEqualTo(problem.correctAnswer * problem.num2)
         }
     }
 
@@ -450,16 +407,15 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Kindergarten mixed should only have ADD or SUB, got: ${problem.operation}",
-                problem.operation in listOf(MathOperation.ADDITION, MathOperation.SUBTRACTION).isTrue(),
-            )
+                problem.operation in listOf(MathOperation.ADDITION, MathOperation.SUBTRACTION),
+            ).isTrue()
         }
 
         // Should have both operations
         val hasAddition = problems.any { it.operation == MathOperation.ADDITION }
         val hasSubtraction = problems.any { it.operation == MathOperation.SUBTRACTION }
-        assertThat("Should have at least one addition problem", hasAddition).isTrue()
-        assertThat("Should have at least one subtraction problem", hasSubtraction).isTrue()
+        assertThat(hasAddition).isTrue()
+        assertThat(hasSubtraction).isTrue()
     }
 
     @Test
@@ -468,23 +424,22 @@ class GradeAwareProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Grade 1 mixed should only have ADD, SUB, or MUL, got: ${problem.operation}",
                 problem.operation in
                     listOf(
                         MathOperation.ADDITION,
                         MathOperation.SUBTRACTION,
                         MathOperation.MULTIPLICATION,
-                    ).isTrue(),
-            )
+                    ),
+            ).isTrue()
         }
 
         // Should have all three operations
         val hasAddition = problems.any { it.operation == MathOperation.ADDITION }
         val hasSubtraction = problems.any { it.operation == MathOperation.SUBTRACTION }
         val hasMultiplication = problems.any { it.operation == MathOperation.MULTIPLICATION }
-        assertThat("Should have at least one addition problem", hasAddition).isTrue()
-        assertThat("Should have at least one subtraction problem", hasSubtraction).isTrue()
-        assertThat("Should have at least one multiplication problem", hasMultiplication).isTrue()
+        assertThat(hasAddition).isTrue()
+        assertThat(hasSubtraction).isTrue()
+        assertThat(hasMultiplication).isTrue()
     }
 
     @Test
@@ -497,10 +452,10 @@ class GradeAwareProblemGeneratorTest {
         val hasMultiplication = problems.any { it.operation == MathOperation.MULTIPLICATION }
         val hasDivision = problems.any { it.operation == MathOperation.DIVISION }
 
-        assertThat("Should have at least one addition problem", hasAddition).isTrue()
-        assertThat("Should have at least one subtraction problem", hasSubtraction).isTrue()
-        assertThat("Should have at least one multiplication problem", hasMultiplication).isTrue()
-        assertThat("Should have at least one division problem", hasDivision).isTrue()
+        assertThat(hasAddition).isTrue()
+        assertThat(hasSubtraction).isTrue()
+        assertThat(hasMultiplication).isTrue()
+        assertThat(hasDivision).isTrue()
     }
 
     @Test
@@ -516,10 +471,7 @@ class GradeAwareProblemGeneratorTest {
                     MathOperation.DIVISION -> problem.num1 / problem.num2
                     MathOperation.MIXED -> throw IllegalStateException("Should not have MIXED operation in results")
                 }
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} ${problem.operation.symbol} ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/generator/SimpleProblemGeneratorTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/generator/SimpleProblemGeneratorTest.kt
@@ -42,8 +42,8 @@ class SimpleProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.ADDITION, defaultGrade)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-10, got: ${problem.num1}", problem.num1 in 1..10).isTrue()
-            assertThat("num2 should be 1-10, got: ${problem.num2}", problem.num2 in 1..10).isTrue()
+            assertThat(problem.num1 in 1..10).isTrue()
+            assertThat(problem.num2 in 1..10).isTrue()
         }
     }
 
@@ -53,10 +53,7 @@ class SimpleProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 + problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} + ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -74,7 +71,7 @@ class SimpleProblemGeneratorTest {
         val problems = generator.generateProblems(10, MathOperation.ADDITION, defaultGrade)
         val ids = problems.map { it.id }.toSet()
 
-        assertThat(problems.size, ids.size).isEqualTo("All problem IDs should be unique")
+        assertThat(problems.size).isEqualTo(ids.size)
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -95,8 +92,8 @@ class SimpleProblemGeneratorTest {
 
         // With 100 problems, we should see multiple different values
         // (not a guarantee due to randomness, but very likely)
-        assertThat("Should generate variety of num1 values", num1Values.size > 3).isTrue()
-        assertThat("Should generate variety of num2 values", num2Values.size > 3).isTrue()
+        assertThat(num1Values.size > 3).isTrue()
+        assertThat(num2Values.size > 3).isTrue()
     }
 
     // ==================== Subtraction Tests ====================
@@ -112,8 +109,8 @@ class SimpleProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.SUBTRACTION, defaultGrade)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-10, got: ${problem.num1}", problem.num1 in 1..10).isTrue()
-            assertThat("num2 should be 1-10, got: ${problem.num2}", problem.num2 in 1..10).isTrue()
+            assertThat(problem.num1 in 1..10).isTrue()
+            assertThat(problem.num2 in 1..10).isTrue()
         }
     }
 
@@ -123,7 +120,6 @@ class SimpleProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should not be negative: ${problem.num1} - ${problem.num2} = ${problem.correctAnswer}",
                 problem.correctAnswer >= 0,
             ).isTrue()
         }
@@ -135,7 +131,6 @@ class SimpleProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "First number should be >= second number: ${problem.num1} >= ${problem.num2}",
                 problem.num1 >= problem.num2,
             ).isTrue()
         }
@@ -147,10 +142,7 @@ class SimpleProblemGeneratorTest {
 
         problems.forEach { problem ->
             val expectedAnswer = problem.num1 - problem.num2
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} - ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -170,8 +162,8 @@ class SimpleProblemGeneratorTest {
         val num2Values = problems.map { it.num2 }.toSet()
 
         // With 100 problems, we should see multiple different values
-        assertThat("Should generate variety of num1 values", num1Values.size > 3).isTrue()
-        assertThat("Should generate variety of num2 values", num2Values.size > 3).isTrue()
+        assertThat(num1Values.size > 3).isTrue()
+        assertThat(num2Values.size > 3).isTrue()
     }
 
     // ==================== Mixed Mode Tests ====================
@@ -189,9 +181,9 @@ class SimpleProblemGeneratorTest {
         val additionCount = problems.count { it.operation == MathOperation.ADDITION }
         val subtractionCount = problems.count { it.operation == MathOperation.SUBTRACTION }
 
-        assertThat("Should have at least one addition problem, got: $additionCount", additionCount > 0).isTrue()
-        assertThat("Should have at least one subtraction problem, got: $subtractionCount", subtractionCount > 0).isTrue()
-        assertThat(100, additionCount + subtractionCount).isEqualTo("All problems should be counted")
+        assertThat(additionCount > 0).isTrue()
+        assertThat(subtractionCount > 0).isTrue()
+        assertThat(100).isEqualTo(additionCount + subtractionCount)
     }
 
     @Test
@@ -199,8 +191,8 @@ class SimpleProblemGeneratorTest {
         val problems = generator.generateProblems(100, MathOperation.MIXED, defaultGrade)
 
         problems.forEach { problem ->
-            assertThat("num1 should be 1-10, got: ${problem.num1}", problem.num1 in 1..10).isTrue()
-            assertThat("num2 should be 1-10, got: ${problem.num2}", problem.num2 in 1..10).isTrue()
+            assertThat(problem.num1 in 1..10).isTrue()
+            assertThat(problem.num2 in 1..10).isTrue()
         }
     }
 
@@ -210,7 +202,6 @@ class SimpleProblemGeneratorTest {
 
         problems.forEach { problem ->
             assertThat(
-                "Answer should not be negative: ${problem.num1} ${problem.operation.symbol} ${problem.num2} = ${problem.correctAnswer}",
                 problem.correctAnswer >= 0,
             ).isTrue()
         }
@@ -227,10 +218,7 @@ class SimpleProblemGeneratorTest {
                     MathOperation.SUBTRACTION -> problem.num1 - problem.num2
                     else -> throw IllegalStateException("Unexpected operation: ${problem.operation}")
                 }
-            assertThat(
-                expectedAnswer,
-                problem.correctAnswer,
-            ).isEqualTo("Problem ${problem.num1} ${problem.operation.symbol} ${problem.num2} has incorrect answer")
+            assertThat(expectedAnswer).isEqualTo(problem.correctAnswer)
         }
     }
 
@@ -244,11 +232,9 @@ class SimpleProblemGeneratorTest {
         // With 200 problems and random 50/50, we expect roughly 100 of each
         // Allow a reasonable margin: 30-70% range (60-140 out of 200)
         assertThat(
-            "Addition count should be between 60-140, got: $additionCount",
             additionCount in 60..140,
         ).isTrue()
         assertThat(
-            "Subtraction count should be between 60-140, got: $subtractionCount",
             subtractionCount in 60..140,
         ).isTrue()
     }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeCategoryTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeCategoryTest.kt
@@ -11,11 +11,11 @@ class BadgeCategoryTest {
 
     @Test
     fun `BadgeCategory values are correctly named`() {
-        assertThat(BadgeCategory.valueOf("GETTING_STARTED").isEqualTo(BadgeCategory.GETTING_STARTED))
-        assertThat(BadgeCategory.valueOf("VOLUME").isEqualTo(BadgeCategory.VOLUME))
-        assertThat(BadgeCategory.valueOf("OPERATION_MASTERY").isEqualTo(BadgeCategory.OPERATION_MASTERY))
-        assertThat(BadgeCategory.valueOf("SPEED_ACCURACY").isEqualTo(BadgeCategory.SPEED_ACCURACY))
-        assertThat(BadgeCategory.valueOf("STREAK").isEqualTo(BadgeCategory.STREAK))
-        assertThat(BadgeCategory.valueOf("GAMES").isEqualTo(BadgeCategory.GAMES))
+        assertThat(BadgeCategory.valueOf("GETTING_STARTED")).isEqualTo(BadgeCategory.GETTING_STARTED)
+        assertThat(BadgeCategory.valueOf("VOLUME")).isEqualTo(BadgeCategory.VOLUME)
+        assertThat(BadgeCategory.valueOf("OPERATION_MASTERY")).isEqualTo(BadgeCategory.OPERATION_MASTERY)
+        assertThat(BadgeCategory.valueOf("SPEED_ACCURACY")).isEqualTo(BadgeCategory.SPEED_ACCURACY)
+        assertThat(BadgeCategory.valueOf("STREAK")).isEqualTo(BadgeCategory.STREAK)
+        assertThat(BadgeCategory.valueOf("GAMES")).isEqualTo(BadgeCategory.GAMES)
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeDefinitionsTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeDefinitionsTest.kt
@@ -8,7 +8,7 @@ class BadgeDefinitionsTest {
     fun `getAllBadges returns 19 badges`() {
         val badges = BadgeDefinitions.getAllBadges()
 
-        assertThat(19, badges.size).isEqualTo("Should have exactly 19 badges")
+        assertThat(badges.size).isEqualTo(19)
     }
 
     @Test
@@ -16,7 +16,7 @@ class BadgeDefinitionsTest {
         val badges = BadgeDefinitions.getAllBadges()
         val ids = badges.map { it.id }
 
-        assertThat(ids.size, ids.distinct().isEqualTo("All badge IDs should be unique").size)
+        assertThat(ids.size).isEqualTo(ids.distinct().size)
     }
 
     @Test
@@ -30,12 +30,12 @@ class BadgeDefinitionsTest {
         val streak = badges.filter { it.category == BadgeCategory.STREAK }
         val games = badges.filter { it.category == BadgeCategory.GAMES }
 
-        assertThat(3, gettingStarted.size).isEqualTo("Should have 3 Getting Started badges")
-        assertThat(4, volume.size).isEqualTo("Should have 4 Volume badges")
-        assertThat(3, operationMastery.size).isEqualTo("Should have 3 Operation Mastery badges")
-        assertThat(3, speedAccuracy.size).isEqualTo("Should have 3 Speed & Accuracy badges")
-        assertThat(2, streak.size).isEqualTo("Should have 2 Streak badges")
-        assertThat(4, games.size).isEqualTo("Should have 4 Games badges")
+        assertThat(gettingStarted.size).isEqualTo(3)
+        assertThat(volume.size).isEqualTo(4)
+        assertThat(operationMastery.size).isEqualTo(3)
+        assertThat(speedAccuracy.size).isEqualTo(3)
+        assertThat(streak.size).isEqualTo(2)
+        assertThat(games.size).isEqualTo(4)
     }
 
     @Test
@@ -43,10 +43,10 @@ class BadgeDefinitionsTest {
         val badges = BadgeDefinitions.getAllBadges()
 
         badges.forEach { badge ->
-            assertThat("Badge ID should not be empty", badge.id.isNotEmpty()).isTrue()
-            assertThat("Badge name should not be empty", badge.name.isNotEmpty()).isTrue()
-            assertThat("Badge description should not be empty", badge.description.isNotEmpty()).isTrue()
-            assertThat("Badge icon should not be empty", badge.icon.isNotEmpty()).isTrue()
+            assertThat(badge.id.isNotEmpty()).isTrue()
+            assertThat(badge.name.isNotEmpty()).isTrue()
+            assertThat(badge.description.isNotEmpty()).isTrue()
+            assertThat(badge.icon.isNotEmpty()).isTrue()
         }
     }
 
@@ -55,7 +55,7 @@ class BadgeDefinitionsTest {
         val badges = BadgeDefinitions.getAllBadges()
 
         badges.forEach { badge ->
-            assertThat(null, badge.unlockedAt).isEqualTo("Badges should not be unlocked by default")
+            assertThat(badge.unlockedAt).isEqualTo(null)
         }
     }
 
@@ -69,7 +69,7 @@ class BadgeDefinitionsTest {
         assertThat(firstSteps?.icon).isEqualTo("🎯")
         assertThat(firstSteps?.category).isEqualTo(BadgeCategory.GETTING_STARTED)
         assertThat(firstSteps?.requirement is BadgeRequirement.ProblemCount).isTrue()
-        assertThat((firstSteps?.requirement as BadgeRequirement.ProblemCount).isEqualTo(1).count)
+        assertThat((firstSteps?.requirement as BadgeRequirement.ProblemCount).count).isEqualTo(1)
     }
 
     @Test
@@ -82,7 +82,7 @@ class BadgeDefinitionsTest {
         assertThat(mathLegend?.icon).isEqualTo("🦅")
         assertThat(mathLegend?.category).isEqualTo(BadgeCategory.VOLUME)
         assertThat(mathLegend?.requirement is BadgeRequirement.ProblemCount).isTrue()
-        assertThat((mathLegend?.requirement as BadgeRequirement.ProblemCount).isEqualTo(500).count)
+        assertThat((mathLegend?.requirement as BadgeRequirement.ProblemCount).count).isEqualTo(500)
     }
 
     @Test
@@ -110,6 +110,6 @@ class BadgeDefinitionsTest {
         assertThat(dedication?.icon).isEqualTo("🏆")
         assertThat(dedication?.category).isEqualTo(BadgeCategory.STREAK)
         assertThat(dedication?.requirement is BadgeRequirement.DailyStreak).isTrue()
-        assertThat((dedication?.requirement as BadgeRequirement.DailyStreak).isEqualTo(7).days)
+        assertThat((dedication?.requirement as BadgeRequirement.DailyStreak).days).isEqualTo(7)
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/BadgeTest.kt
@@ -18,7 +18,7 @@ class BadgeTest {
                 unlockedAt = Instant.now(),
             )
 
-        assertThat("Badge should be unlocked when unlockedAt is set", badge.isUnlocked()).isTrue()
+        assertThat(badge.isUnlocked()).isTrue()
     }
 
     @Test
@@ -34,7 +34,7 @@ class BadgeTest {
                 unlockedAt = null,
             )
 
-        assertThat("Badge should be locked when unlockedAt is null", badge.isUnlocked()).isFalse()
+        assertThat(badge.isUnlocked()).isFalse()
     }
 
     @Test
@@ -57,7 +57,7 @@ class BadgeTest {
         assertThat(badge.icon).isEqualTo("🎯")
         assertThat(badge.category).isEqualTo(BadgeCategory.GETTING_STARTED)
         assertThat(badge.requirement is BadgeRequirement.ProblemCount).isTrue()
-        assertThat((badge.requirement as BadgeRequirement.ProblemCount).isEqualTo(1).count)
+        assertThat((badge.requirement as BadgeRequirement.ProblemCount).count).isEqualTo(1)
         assertThat(badge.unlockedAt).isEqualTo(unlockedAt)
     }
 
@@ -73,6 +73,6 @@ class BadgeTest {
                 requirement = BadgeRequirement.ProblemCount(10),
             )
 
-        assertThat("Badge should be locked by default", badge.isUnlocked()).isFalse()
+        assertThat(badge.isUnlocked()).isFalse()
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/GameSessionTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/GameSessionTest.kt
@@ -68,31 +68,31 @@ class GameSessionTest {
     @Test
     fun `getStarRating returns 5 for 90+ accuracy`() {
         val session = createSession(correctAnswers = 9, totalAttempts = 10)
-        assertThat(session.getStarRating().isEqualTo(5))
+        assertThat(session.getStarRating()).isEqualTo(5)
     }
 
     @Test
     fun `getStarRating returns 4 for 80-89 accuracy`() {
         val session = createSession(correctAnswers = 8, totalAttempts = 10)
-        assertThat(session.getStarRating().isEqualTo(4))
+        assertThat(session.getStarRating()).isEqualTo(4)
     }
 
     @Test
     fun `getStarRating returns 3 for 70-79 accuracy`() {
         val session = createSession(correctAnswers = 7, totalAttempts = 10)
-        assertThat(session.getStarRating().isEqualTo(3))
+        assertThat(session.getStarRating()).isEqualTo(3)
     }
 
     @Test
     fun `getStarRating returns 2 for 60-69 accuracy`() {
         val session = createSession(correctAnswers = 6, totalAttempts = 10)
-        assertThat(session.getStarRating().isEqualTo(2))
+        assertThat(session.getStarRating()).isEqualTo(2)
     }
 
     @Test
     fun `getStarRating returns 1 for less than 60 accuracy`() {
         val session = createSession(correctAnswers = 5, totalAttempts = 10)
-        assertThat(session.getStarRating().isEqualTo(1))
+        assertThat(session.getStarRating()).isEqualTo(1)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/GameStatsTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/GameStatsTest.kt
@@ -32,37 +32,37 @@ class GameStatsTest {
     @Test
     fun `getStarRating returns 0 when never played`() {
         val stats = createStats(totalGamesPlayed = 0, bestAccuracy = 100f)
-        assertThat(stats.getStarRating().isEqualTo(0))
+        assertThat(stats.getStarRating()).isEqualTo(0)
     }
 
     @Test
     fun `getStarRating returns 5 for 90+ best accuracy`() {
         val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 95f)
-        assertThat(stats.getStarRating().isEqualTo(5))
+        assertThat(stats.getStarRating()).isEqualTo(5)
     }
 
     @Test
     fun `getStarRating returns 4 for 80-89 best accuracy`() {
         val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 85f)
-        assertThat(stats.getStarRating().isEqualTo(4))
+        assertThat(stats.getStarRating()).isEqualTo(4)
     }
 
     @Test
     fun `getStarRating returns 3 for 70-79 best accuracy`() {
         val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 75f)
-        assertThat(stats.getStarRating().isEqualTo(3))
+        assertThat(stats.getStarRating()).isEqualTo(3)
     }
 
     @Test
     fun `getStarRating returns 2 for 60-69 best accuracy`() {
         val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 65f)
-        assertThat(stats.getStarRating().isEqualTo(2))
+        assertThat(stats.getStarRating()).isEqualTo(2)
     }
 
     @Test
     fun `getStarRating returns 1 for less than 60 best accuracy`() {
         val stats = createStats(totalGamesPlayed = 1, bestAccuracy = 50f)
-        assertThat(stats.getStarRating().isEqualTo(1))
+        assertThat(stats.getStarRating()).isEqualTo(1)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/GameTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/GameTest.kt
@@ -11,9 +11,9 @@ class GameTest {
 
     @Test
     fun `Game values are correctly named`() {
-        assertThat(Game.valueOf("MATH_RACE").isEqualTo(Game.MATH_RACE))
-        assertThat(Game.valueOf("MEMORY_MATCH").isEqualTo(Game.MEMORY_MATCH))
-        assertThat(Game.valueOf("NUMBER_SEQUENCE").isEqualTo(Game.NUMBER_SEQUENCE))
+        assertThat(Game.valueOf("MATH_RACE")).isEqualTo(Game.MATH_RACE)
+        assertThat(Game.valueOf("MEMORY_MATCH")).isEqualTo(Game.MEMORY_MATCH)
+        assertThat(Game.valueOf("NUMBER_SEQUENCE")).isEqualTo(Game.NUMBER_SEQUENCE)
     }
 
     @Test
@@ -70,40 +70,40 @@ class GameTest {
     // unlockProgress tests
     @Test
     fun `unlockProgress returns 0 when no problems solved`() {
-        assertThat(Game.MATH_RACE.unlockProgress(0).isEqualTo(0f))
+        assertThat(Game.MATH_RACE.unlockProgress(0)).isEqualTo(0f)
     }
 
     @Test
     fun `unlockProgress returns correct fraction`() {
-        assertThat(Game.MATH_RACE.unlockProgress(25).isEqualTo(0.5f))
-        assertThat(Game.MEMORY_MATCH.unlockProgress(50).isEqualTo(0.5f))
-        assertThat(Game.NUMBER_SEQUENCE.unlockProgress(100).isEqualTo(0.5f))
+        assertThat(Game.MATH_RACE.unlockProgress(25)).isEqualTo(0.5f)
+        assertThat(Game.MEMORY_MATCH.unlockProgress(50)).isEqualTo(0.5f)
+        assertThat(Game.NUMBER_SEQUENCE.unlockProgress(100)).isEqualTo(0.5f)
     }
 
     @Test
     fun `unlockProgress caps at 1 when requirement met`() {
-        assertThat(Game.MATH_RACE.unlockProgress(50).isEqualTo(1f))
-        assertThat(Game.MATH_RACE.unlockProgress(100).isEqualTo(1f))
+        assertThat(Game.MATH_RACE.unlockProgress(50)).isEqualTo(1f)
+        assertThat(Game.MATH_RACE.unlockProgress(100)).isEqualTo(1f)
     }
 
     // problemsUntilUnlock tests
     @Test
     fun `problemsUntilUnlock returns requirement when no problems solved`() {
-        assertThat(Game.MATH_RACE.problemsUntilUnlock(0).isEqualTo(50))
-        assertThat(Game.MEMORY_MATCH.problemsUntilUnlock(0).isEqualTo(100))
-        assertThat(Game.NUMBER_SEQUENCE.problemsUntilUnlock(0).isEqualTo(200))
+        assertThat(Game.MATH_RACE.problemsUntilUnlock(0)).isEqualTo(50)
+        assertThat(Game.MEMORY_MATCH.problemsUntilUnlock(0)).isEqualTo(100)
+        assertThat(Game.NUMBER_SEQUENCE.problemsUntilUnlock(0)).isEqualTo(200)
     }
 
     @Test
     fun `problemsUntilUnlock returns remaining problems`() {
-        assertThat(Game.MATH_RACE.problemsUntilUnlock(25).isEqualTo(25))
-        assertThat(Game.MEMORY_MATCH.problemsUntilUnlock(50).isEqualTo(50))
-        assertThat(Game.NUMBER_SEQUENCE.problemsUntilUnlock(100).isEqualTo(100))
+        assertThat(Game.MATH_RACE.problemsUntilUnlock(25)).isEqualTo(25)
+        assertThat(Game.MEMORY_MATCH.problemsUntilUnlock(50)).isEqualTo(50)
+        assertThat(Game.NUMBER_SEQUENCE.problemsUntilUnlock(100)).isEqualTo(100)
     }
 
     @Test
     fun `problemsUntilUnlock returns 0 when requirement met`() {
-        assertThat(Game.MATH_RACE.problemsUntilUnlock(50).isEqualTo(0))
-        assertThat(Game.MATH_RACE.problemsUntilUnlock(100).isEqualTo(0))
+        assertThat(Game.MATH_RACE.problemsUntilUnlock(50)).isEqualTo(0)
+        assertThat(Game.MATH_RACE.problemsUntilUnlock(100)).isEqualTo(0)
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/MathProblemTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/MathProblemTest.kt
@@ -14,7 +14,7 @@ class MathProblemTest {
                 correctAnswer = 8,
             )
 
-        assertThat(problem.getDisplayString().isEqualTo("3 + 5 = ?"))
+        assertThat(problem.getDisplayString()).isEqualTo("3 + 5 = ?")
     }
 
     @Test
@@ -27,7 +27,7 @@ class MathProblemTest {
                 correctAnswer = 6,
             )
 
-        assertThat(problem.getDisplayString().isEqualTo("10 - 4 = ?"))
+        assertThat(problem.getDisplayString()).isEqualTo("10 - 4 = ?")
     }
 
     @Test
@@ -40,7 +40,7 @@ class MathProblemTest {
                 correctAnswer = 21,
             )
 
-        assertThat(problem.getDisplayString().isEqualTo("7 × 3 = ?"))
+        assertThat(problem.getDisplayString()).isEqualTo("7 × 3 = ?")
     }
 
     @Test
@@ -53,7 +53,7 @@ class MathProblemTest {
                 correctAnswer = 4,
             )
 
-        assertThat(problem.getDisplayString().isEqualTo("20 ÷ 5 = ?"))
+        assertThat(problem.getDisplayString()).isEqualTo("20 ÷ 5 = ?")
     }
 
     @Test
@@ -115,7 +115,7 @@ class MathProblemTest {
                 correctAnswer = 8,
             )
 
-        assertThat(problem.getSpokenString().isEqualTo("3 plus 5 equals"))
+        assertThat(problem.getSpokenString()).isEqualTo("3 plus 5 equals")
     }
 
     @Test
@@ -128,7 +128,7 @@ class MathProblemTest {
                 correctAnswer = 6,
             )
 
-        assertThat(problem.getSpokenString().isEqualTo("10 minus 4 equals"))
+        assertThat(problem.getSpokenString()).isEqualTo("10 minus 4 equals")
     }
 
     @Test
@@ -141,7 +141,7 @@ class MathProblemTest {
                 correctAnswer = 21,
             )
 
-        assertThat(problem.getSpokenString().isEqualTo("7 times 3 equals"))
+        assertThat(problem.getSpokenString()).isEqualTo("7 times 3 equals")
     }
 
     @Test
@@ -154,6 +154,6 @@ class MathProblemTest {
                 correctAnswer = 4,
             )
 
-        assertThat(problem.getSpokenString().isEqualTo("20 divided by 5 equals"))
+        assertThat(problem.getSpokenString()).isEqualTo("20 divided by 5 equals")
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/OperationPerformanceTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/OperationPerformanceTest.kt
@@ -139,7 +139,7 @@ class OperationPerformanceTest {
                 recentAttempts = 20,
             )
 
-        assertThat(performance.getRecommendedAdjustment().isEqualTo(DifficultyAdjustment.HARDER))
+        assertThat(performance.getRecommendedAdjustment()).isEqualTo(DifficultyAdjustment.HARDER)
     }
 
     @Test
@@ -154,7 +154,7 @@ class OperationPerformanceTest {
                 recentAttempts = 10,
             )
 
-        assertThat(performance.getRecommendedAdjustment().isEqualTo(DifficultyAdjustment.EASIER))
+        assertThat(performance.getRecommendedAdjustment()).isEqualTo(DifficultyAdjustment.EASIER)
     }
 
     @Test
@@ -169,7 +169,7 @@ class OperationPerformanceTest {
                 recentAttempts = 15,
             )
 
-        assertThat(performance.getRecommendedAdjustment().isEqualTo(DifficultyAdjustment.CURRENT))
+        assertThat(performance.getRecommendedAdjustment()).isEqualTo(DifficultyAdjustment.CURRENT)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/PracticeSessionTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/PracticeSessionTest.kt
@@ -22,7 +22,7 @@ class PracticeSessionTest {
                 problems = emptyList(),
             )
 
-        assertThat(session.getCorrectCount().isEqualTo(0))
+        assertThat(session.getCorrectCount()).isEqualTo(0)
     }
 
     @Test
@@ -39,7 +39,7 @@ class PracticeSessionTest {
         session.answers["4"] = SessionAnswer("4", 8, isCorrect = true)
         session.answers["5"] = SessionAnswer("5", 7, isCorrect = false)
 
-        assertThat(session.getCorrectCount().isEqualTo(3))
+        assertThat(session.getCorrectCount()).isEqualTo(3)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/domain/model/SessionStatsTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/domain/model/SessionStatsTest.kt
@@ -7,61 +7,61 @@ class SessionStatsTest {
     @Test
     fun `getStarRating returns 5 stars for 90-100 percent accuracy`() {
         val stats = SessionStats(100, 90, 90f, 1)
-        assertThat(stats.getStarRating().isEqualTo(5))
+        assertThat(stats.getStarRating()).isEqualTo(5)
 
         val stats95 = SessionStats(100, 95, 95f, 1)
-        assertThat(stats95.getStarRating().isEqualTo(5))
+        assertThat(stats95.getStarRating()).isEqualTo(5)
 
         val stats100 = SessionStats(100, 100, 100f, 1)
-        assertThat(stats100.getStarRating().isEqualTo(5))
+        assertThat(stats100.getStarRating()).isEqualTo(5)
     }
 
     @Test
     fun `getStarRating returns 4 stars for 80-89 percent accuracy`() {
         val stats = SessionStats(100, 80, 80f, 1)
-        assertThat(stats.getStarRating().isEqualTo(4))
+        assertThat(stats.getStarRating()).isEqualTo(4)
 
         val stats85 = SessionStats(100, 85, 85f, 1)
-        assertThat(stats85.getStarRating().isEqualTo(4))
+        assertThat(stats85.getStarRating()).isEqualTo(4)
 
         val stats89 = SessionStats(100, 89, 89f, 1)
-        assertThat(stats89.getStarRating().isEqualTo(4))
+        assertThat(stats89.getStarRating()).isEqualTo(4)
     }
 
     @Test
     fun `getStarRating returns 3 stars for 70-79 percent accuracy`() {
         val stats = SessionStats(100, 70, 70f, 1)
-        assertThat(stats.getStarRating().isEqualTo(3))
+        assertThat(stats.getStarRating()).isEqualTo(3)
 
         val stats75 = SessionStats(100, 75, 75f, 1)
-        assertThat(stats75.getStarRating().isEqualTo(3))
+        assertThat(stats75.getStarRating()).isEqualTo(3)
 
         val stats79 = SessionStats(100, 79, 79f, 1)
-        assertThat(stats79.getStarRating().isEqualTo(3))
+        assertThat(stats79.getStarRating()).isEqualTo(3)
     }
 
     @Test
     fun `getStarRating returns 2 stars for 60-69 percent accuracy`() {
         val stats = SessionStats(100, 60, 60f, 1)
-        assertThat(stats.getStarRating().isEqualTo(2))
+        assertThat(stats.getStarRating()).isEqualTo(2)
 
         val stats65 = SessionStats(100, 65, 65f, 1)
-        assertThat(stats65.getStarRating().isEqualTo(2))
+        assertThat(stats65.getStarRating()).isEqualTo(2)
 
         val stats69 = SessionStats(100, 69, 69f, 1)
-        assertThat(stats69.getStarRating().isEqualTo(2))
+        assertThat(stats69.getStarRating()).isEqualTo(2)
     }
 
     @Test
     fun `getStarRating returns 1 star for less than 60 percent accuracy`() {
         val stats = SessionStats(100, 59, 59f, 1)
-        assertThat(stats.getStarRating().isEqualTo(1))
+        assertThat(stats.getStarRating()).isEqualTo(1)
 
         val stats50 = SessionStats(100, 50, 50f, 1)
-        assertThat(stats50.getStarRating().isEqualTo(1))
+        assertThat(stats50.getStarRating()).isEqualTo(1)
 
         val stats0 = SessionStats(100, 0, 0f, 1)
-        assertThat(stats0.getStarRating().isEqualTo(1))
+        assertThat(stats0.getStarRating()).isEqualTo(1)
     }
 
     @Test
@@ -74,6 +74,6 @@ class SessionStatsTest {
 
     @Test
     fun `EMPTY returns 1 star rating`() {
-        assertThat(SessionStats.EMPTY.getStarRating().isEqualTo(1))
+        assertThat(SessionStats.EMPTY.getStarRating()).isEqualTo(1)
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/ui/badges/BadgesScreenTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/badges/BadgesScreenTest.kt
@@ -206,7 +206,7 @@ class BadgesScreenTest {
         // Then
         assertThat(receivedEvent).isNotNull()
         assertThat(receivedEvent is BadgesScreen.Event.BadgeClicked).isTrue()
-        assertThat((receivedEvent as BadgesScreen.Event.BadgeClicked).isEqualTo(badge).badge)
+        assertThat((receivedEvent as BadgesScreen.Event.BadgeClicked).badge).isEqualTo(badge)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/ui/games/GameSelectionPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/games/GameSelectionPresenterTest.kt
@@ -73,10 +73,10 @@ class GameSelectionPresenterTest {
     fun `problems until unlock calculated correctly`() {
         val game = Game.MATH_RACE // 50 problems required
 
-        assertThat(game.problemsUntilUnlock(0).isEqualTo(50))
-        assertThat(game.problemsUntilUnlock(25).isEqualTo(25))
-        assertThat(game.problemsUntilUnlock(50).isEqualTo(0))
-        assertThat(game.problemsUntilUnlock(100).isEqualTo(0)) // Already unlocked
+        assertThat(game.problemsUntilUnlock(0)).isEqualTo(50)
+        assertThat(game.problemsUntilUnlock(25)).isEqualTo(25)
+        assertThat(game.problemsUntilUnlock(50)).isEqualTo(0)
+        assertThat(game.problemsUntilUnlock(100)).isEqualTo(0) // Already unlocked
     }
 
     @Test
@@ -101,40 +101,16 @@ class GameSelectionPresenterTest {
 
     @Test
     fun `game icons are defined`() {
-        assertThat(
-            Game.MATH_RACE.icon
-                .isNotEmpty()
-                .isTrue(),
-        )
-        assertThat(
-            Game.MEMORY_MATCH.icon
-                .isNotEmpty()
-                .isTrue(),
-        )
-        assertThat(
-            Game.NUMBER_SEQUENCE.icon
-                .isNotEmpty()
-                .isTrue(),
-        )
+        assertThat(Game.MATH_RACE.icon.isNotEmpty()).isTrue()
+        assertThat(Game.MEMORY_MATCH.icon.isNotEmpty()).isTrue()
+        assertThat(Game.NUMBER_SEQUENCE.icon.isNotEmpty()).isTrue()
     }
 
     @Test
     fun `game descriptions are defined`() {
-        assertThat(
-            Game.MATH_RACE.description
-                .isNotEmpty()
-                .isTrue(),
-        )
-        assertThat(
-            Game.MEMORY_MATCH.description
-                .isNotEmpty()
-                .isTrue(),
-        )
-        assertThat(
-            Game.NUMBER_SEQUENCE.description
-                .isNotEmpty()
-                .isTrue(),
-        )
+        assertThat(Game.MATH_RACE.description.isNotEmpty()).isTrue()
+        assertThat(Game.MEMORY_MATCH.description.isNotEmpty()).isTrue()
+        assertThat(Game.NUMBER_SEQUENCE.description.isNotEmpty()).isTrue()
     }
 
     // ==================== State Tests ====================

--- a/app/src/test/java/dev/hossain/mathtutor/ui/home/HomeScreenTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/home/HomeScreenTest.kt
@@ -359,7 +359,7 @@ class HomeScreenTest {
         assertThat(state.streakData?.currentStreak).isEqualTo(5)
         assertThat(state.streakData?.longestStreak).isEqualTo(7)
         assertThat(state.streakData?.lastPracticeDate).isEqualTo(today)
-        assertThat(state.streakData?.isStreakAlive(today).isTrue() == true)
+        assertThat(state.streakData?.isStreakAlive(today)).isTrue()
     }
 
     @Test
@@ -390,7 +390,7 @@ class HomeScreenTest {
         // Then
         assertThat(state.streakData?.currentStreak).isEqualTo(3)
         assertThat(state.streakData?.lastPracticeDate).isEqualTo(yesterday)
-        assertThat(state.streakData?.isStreakAlive(today).isTrue() == true)
+        assertThat(state.streakData?.isStreakAlive(today)).isTrue()
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenterTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenterTest.kt
@@ -48,7 +48,7 @@ class MathPracticePresenterTest {
         // Then - Initial state should be set correctly
         assertThat(problems.size).isEqualTo(5)
         assertThat(problems[0]).isNotNull()
-        assertThat(problems[0].getDisplayString().isEqualTo("1 + 1 = ?"))
+        assertThat(problems[0].getDisplayString()).isEqualTo("1 + 1 = ?")
     }
 
     @Test
@@ -76,7 +76,7 @@ class MathPracticePresenterTest {
 
         // Then
         assertThat(currentAnswer).isEqualTo("")
-        assertThat(isCorrect).isNull()
+        assertThat(isCorrect as Boolean?).isNull()
     }
 
     @Test
@@ -162,7 +162,7 @@ class MathPracticePresenterTest {
         // Then
         assertThat(currentProblemIndex).isEqualTo(1)
         assertThat(currentAnswer).isEqualTo("")
-        assertThat(isCorrect).isNull()
+        assertThat(isCorrect as Boolean?).isNull()
     }
 
     @Test
@@ -203,7 +203,7 @@ class MathPracticePresenterTest {
 
         // Then
         assertThat(currentProblemIndex).isEqualTo(5)
-        assertThat((currentProblemIndex + 1).isEqualTo(0.6f).toFloat() / totalProblems, 0.01f)
+        assertThat((currentProblemIndex + 1).toFloat() / totalProblems).isWithin(0.01f).of(0.6f)
     }
 
     @Test
@@ -325,7 +325,7 @@ class MathPracticePresenterTest {
         assertThat(practiceSession.durationSeconds).isEqualTo(120L)
         assertThat(practiceSession.completedAt).isEqualTo(completedAt)
         assertThat(practiceSession.isComplete()).isTrue()
-        assertThat(practiceSession.getCorrectCount().isEqualTo(3))
+        assertThat(practiceSession.getCorrectCount()).isEqualTo(3)
     }
 
     @Test


### PR DESCRIPTION
## Changes

This PR fixes Truth assertion syntax errors across all test files after updating to Google Truth library.

### Fixed Issues
- ✅ Move `isEqualTo()`, `isTrue()`, `isFalse()`, `isNull()` outside of `assertThat()` parentheses
- ✅ Fix assertions with type casts: `(obj as Type).isEqualTo(x).property` → `(obj as Type).property.isEqualTo(x)`
- ✅ Remove unsupported message parameters from `assertThat()`
- ✅ Fix nullable Boolean type ambiguity with explicit casts
- ✅ Fix method chaining issues like `.isNotEmpty().isTrue()`

### Files Modified (19 files)
- Phase3EdgeCasesTest.kt
- BadgeMapperTest.kt
- UserProfileRepositoryImplTest.kt
- AdaptiveProblemGeneratorTest.kt
- GradeAwareProblemGeneratorTest.kt
- SimpleProblemGeneratorTest.kt
- BadgeCategoryTest.kt
- BadgeDefinitionsTest.kt
- BadgeTest.kt
- GameSessionTest.kt
- GameStatsTest.kt
- GameTest.kt
- MathProblemTest.kt
- OperationPerformanceTest.kt
- PracticeSessionTest.kt
- SessionStatsTest.kt
- BadgesScreenTest.kt
- GameSelectionPresenterTest.kt
- HomeScreenTest.kt
- MathPracticePresenterTest.kt

### Verification
- ✅ All tests compile successfully
- ✅ Code formatted with `./gradlew formatKotlin`

Closes related issues with Truth assertion syntax after migration from JUnit assertions.