### PR TITLE
fix: Add BackHandler to Settings to prevent ANR on system back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **ANR when pressing system back from Settings screen** - Fixed Application Not Responding issue when using system back button to exit Settings
+  - Added `BackHandler` to SettingsUi to explicitly handle system back navigation
+  - Ensures immediate response to back button press without blocking UI thread
+
 ### Added
 - **Compose Previews for UI Components** - Added comprehensive preview support for better UI development experience
   - Added previews with light and dark mode variants for `GameSelectionUi.kt`, `GradeChangeDialog.kt`, and `NameEditDialog.kt`

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
@@ -121,6 +121,7 @@ class SettingsPresenter
 
                     is SettingsScreen.Event.BackClicked -> {
                         Timber.d("SettingsScreen: Back clicked")
+                        // Navigate immediately without blocking
                         navigator.pop()
                     }
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
@@ -1,5 +1,6 @@
 package dev.hossain.mathtutor.ui.settings
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -52,6 +53,11 @@ fun SettingsUi(
     state: SettingsScreen.State,
     modifier: Modifier = Modifier,
 ) {
+    // Handle system back button press
+    BackHandler {
+        state.eventSink(SettingsScreen.Event.BackClicked)
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(


### PR DESCRIPTION
## Description
Fixes ANR (Application Not Responding) issue that occurred when pressing the system back button to exit the Settings screen.

## Problem
When users pressed the system back button from Settings, the app would freeze for 5+ seconds before responding, causing an ANR dialog.

## Solution
Added explicit `BackHandler` in `SettingsUi` to handle system back button presses immediately and trigger navigation without blocking the UI thread.

## Testing
✅ Tested back navigation from Settings screen multiple times
✅ Back navigation now responds in ~160-180ms (previously 5+ seconds)
✅ No ANR occurs
✅ Build successful

## Changes
- Added `BackHandler` import to [SettingsUi.kt](app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt)
- Added `BackHandler` block to handle system back button
- Updated [CHANGELOG.md](CHANGELOG.md) with fix details

## Logs (Before vs After)
**Before:** 5+ second freeze with ANR signal
**After:** 
```
18:17:05.270  D  SettingsScreen: Back clicked
18:17:05.453  D  HomeScreen: User profile - name=null, grade=null  (~180ms response)
```