### PR TITLE
fix: Add BackHandler to Games screen to prevent ANR on system back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **ANR when pressing system back from Settings screen** - Fixed Application Not Responding issue when using system back button to exit Settings
-  - Added `BackHandler` to SettingsUi to explicitly handle system back navigation
+- **ANR when pressing system back from Settings and Games screens** - Fixed Application Not Responding issue when using system back button
+  - Added `BackHandler` to SettingsUi and GameSelectionUi to explicitly handle system back navigation
   - Ensures immediate response to back button press without blocking UI thread
+  - Prevents 5+ second freeze when exiting these screens
 
 ### Added
 - **Compose Previews for UI Components** - Added comprehensive preview support for better UI development experience

--- a/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionUi.kt
@@ -1,5 +1,6 @@
 package dev.hossain.mathtutor.ui.games
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -51,6 +52,11 @@ fun GameSelectionUi(
     state: GameSelectionScreen.State,
     modifier: Modifier = Modifier,
 ) {
+    // Handle system back button press
+    BackHandler {
+        state.eventSink(GameSelectionScreen.Event.NavigateBack)
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionUi.kt
@@ -52,7 +52,16 @@ fun GameSelectionUi(
     state: GameSelectionScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    // Handle system back button press
+    /*
+     * IMPORTANT: Explicit BackHandler to prevent ANR on system back button press.
+     *
+     * Without this BackHandler, pressing the system back button causes a 5+ second freeze
+     * with 97-110% CPU usage on the main thread, triggering an ANR (Application Not Responding).
+     * The BackHandler ensures immediate navigation response by handling the back event directly
+     * and triggering navigation without blocking the UI thread.
+     *
+     * See: PR #143 for details on the ANR issue and fix.
+     */
     BackHandler {
         state.eventSink(GameSelectionScreen.Event.NavigateBack)
     }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeUi.kt
@@ -113,7 +113,11 @@ internal fun MathPracticeUi(
         previousIsCorrect = state.isCorrect
     }
 
-    // Handle system back button
+    /*
+     * Handle system back button to show exit confirmation.
+     * This prevents accidental exits during practice which would lose progress.
+     * Different from Settings/Games BackHandler which prevents ANR - this is intentional UX.
+     */
     BackHandler {
         showExitDialog = true
     }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
@@ -53,7 +53,16 @@ fun SettingsUi(
     state: SettingsScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    // Handle system back button press
+    /*
+     * IMPORTANT: Explicit BackHandler to prevent ANR on system back button press.
+     *
+     * Without this BackHandler, pressing the system back button causes a 5+ second freeze
+     * with 97-110% CPU usage on the main thread, triggering an ANR (Application Not Responding).
+     * The BackHandler ensures immediate navigation response by handling the back event directly
+     * and triggering navigation without blocking the UI thread.
+     *
+     * See: PR #142 for details on the ANR issue and fix.
+     */
     BackHandler {
         state.eventSink(SettingsScreen.Event.BackClicked)
     }


### PR DESCRIPTION
## Description
Fixes ANR (Application Not Responding) issue when pressing the system back button to exit the Games screen - same issue pattern as the Settings screen ANR.

## Problem
When users pressed the system back button from Game Selection screen, the app would freeze for 5+ seconds with 97% CPU usage before responding, causing an ANR dialog.

## Solution
Added explicit `BackHandler` in `GameSelectionUi` to handle system back button presses immediately and trigger navigation without blocking the UI thread.

## Testing
✅ Build successful
✅ Applied same fix pattern that resolved Settings screen ANR

## Changes
- Added `BackHandler` import to [GameSelectionUi.kt](app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionUi.kt)
- Added `BackHandler` block to handle system back button
- Updated [CHANGELOG.md](CHANGELOG.md) to include both Settings and Games screens

## Related
- Related to PR #142 (Settings screen ANR fix)
- Same root cause and solution pattern