### PR TITLE
feat: Add analytics tracking to onboarding screens (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive unit tests for `FakeAnalyticsService` with 23 test cases
   - Helper methods for querying recorded events in tests
   - Implementation for Issue #146 (Test Implementations)
+- **Onboarding Analytics Tracking** - Added analytics tracking to onboarding flow
+  - Track screen views for all 3 onboarding screens (Onboarding, GradeSelection, NameEntry)
+  - Track `onboarding_started` event when onboarding begins
+  - Track `onboarding_completed` event when user completes or skips onboarding
+  - Track `grade_selected` event with grade level parameter
+  - Track `name_entered` event with skipped status
+  - Uses Circuit's `LaunchedImpressionEffect` for automatic screen view tracking
+  - Implementation for Issue #147 (Onboarding Screen Tracking)
 
 ### Fixed
 - **ANR when pressing system back from Settings and Games screens** - Fixed Application Not Responding issue when using system back button

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -47,6 +47,10 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.domain.model.GradeLevel
 import dev.hossain.mathtutor.domain.model.UserProfile
 import dev.hossain.mathtutor.domain.repository.UserProfileRepository
@@ -121,6 +125,7 @@ class GradeSelectionPresenter
         @Assisted private val screen: GradeSelectionScreen,
         @Assisted private val navigator: Navigator,
         private val userProfileRepository: UserProfileRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<GradeSelectionScreen.State> {
         @CircuitInject(GradeSelectionScreen::class, AppScope::class)
         @AssistedFactory
@@ -136,6 +141,18 @@ class GradeSelectionPresenter
             val scope = rememberCoroutineScope()
             var selectedGrade by remember { mutableStateOf<GradeLevel?>(null) }
 
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Grade Selection",
+                    screenClass = GradeSelectionScreen::class.java.name,
+                    parameters =
+                        mapOf(
+                            "is_from_settings" to screen.isFromSettings,
+                        ),
+                )
+            }
+
             // Collect current profile to check if it exists (for settings mode)
             val currentProfile by userProfileRepository.getProfile().collectAsState(initial = null)
 
@@ -146,6 +163,13 @@ class GradeSelectionPresenter
                 when (event) {
                     is GradeSelectionScreen.Event.GradeSelected -> {
                         selectedGrade = event.grade
+                        // Track grade selection
+                        analyticsService.logEvent(
+                            AnalyticsEvent.GRADE_SELECTED,
+                            mapOf(
+                                AnalyticsParam.GRADE_LEVEL to event.grade.name,
+                            ),
+                        )
                     }
 
                     is GradeSelectionScreen.Event.ContinueClicked -> {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/NameEntryScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/NameEntryScreen.kt
@@ -37,6 +37,9 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.domain.model.GradeLevel
 import dev.hossain.mathtutor.domain.model.UserProfile
 import dev.hossain.mathtutor.domain.repository.UserProfileRepository
@@ -105,6 +108,7 @@ class NameEntryPresenter
         @Assisted private val screen: NameEntryScreen,
         @Assisted private val navigator: Navigator,
         private val userProfileRepository: UserProfileRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<NameEntryScreen.State> {
         @CircuitInject(NameEntryScreen::class, AppScope::class)
         @AssistedFactory
@@ -120,6 +124,14 @@ class NameEntryPresenter
             var name by remember { mutableStateOf("") }
             val coroutineScope = rememberCoroutineScope()
 
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Name Entry",
+                    screenClass = NameEntryScreen::class.java.name,
+                )
+            }
+
             return NameEntryScreen.State(
                 name = name,
             ) { event ->
@@ -129,6 +141,11 @@ class NameEntryPresenter
                     }
 
                     is NameEntryScreen.Event.SkipClicked -> {
+                        // Track name skipped
+                        analyticsService.logEvent(
+                            AnalyticsEvent.NAME_ENTERED,
+                            mapOf("skipped" to true),
+                        )
                         // Save profile without name
                         coroutineScope.launch {
                             userProfileRepository.saveProfile(
@@ -144,6 +161,12 @@ class NameEntryPresenter
                     }
 
                     is NameEntryScreen.Event.ContinueClicked -> {
+                        // Track name entered
+                        val hasName = name.trim().isNotBlank()
+                        analyticsService.logEvent(
+                            AnalyticsEvent.NAME_ENTERED,
+                            mapOf("skipped" to !hasName),
+                        )
                         // Save profile with name (or null if empty)
                         coroutineScope.launch {
                             userProfileRepository.saveProfile(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/OnboardingScreen.kt
@@ -48,7 +48,10 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuitx.effects.LaunchedImpressionEffect
 import dev.hossain.mathtutor.R
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.data.UserPreferencesRepository
 import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
 import dev.zacsweers.metro.AppScope
@@ -114,11 +117,21 @@ class OnboardingPresenter
     constructor(
         @Assisted private val navigator: Navigator,
         private val userPreferencesRepository: UserPreferencesRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<OnboardingScreen.State> {
         @Composable
         override fun present(): OnboardingScreen.State {
             val coroutineScope = rememberCoroutineScope()
             var currentPage = 0
+
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Onboarding",
+                    screenClass = OnboardingScreen::class.java.name,
+                )
+                analyticsService.logEvent(AnalyticsEvent.ONBOARDING_STARTED)
+            }
 
             return OnboardingScreen.State(
                 currentPage = currentPage,
@@ -138,6 +151,8 @@ class OnboardingPresenter
                     -> {
                         coroutineScope.launch {
                             userPreferencesRepository.setOnboardingCompleted(true)
+                            // Track onboarding completed
+                            analyticsService.logEvent(AnalyticsEvent.ONBOARDING_COMPLETED)
                             navigator.goTo(GradeSelectionScreen())
                         }
                     }


### PR DESCRIPTION
## Description

Implements Issue #147 - Analytics tracking for the 3 onboarding screens.

This PR adds comprehensive analytics tracking to the onboarding flow, capturing screen views and key user actions throughout the onboarding journey.

## Changes

### Modified Files

#### OnboardingScreen.kt
- Injected `AnalyticsService` into `OnboardingPresenter`
- Added `LaunchedImpressionEffect` for screen view tracking
- Track `onboarding_started` event when screen loads
- Track `onboarding_completed` event when user completes or skips

#### GradeSelectionScreen.kt
- Injected `AnalyticsService` into `GradeSelectionPresenter`
- Added `LaunchedImpressionEffect` for screen view tracking
- Track screen view with `is_from_settings` parameter (for settings vs onboarding context)
- Track `grade_selected` event with `grade_level` parameter when user selects grade

#### NameEntryScreen.kt
- Injected `AnalyticsService` into `NameEntryPresenter`
- Added `LaunchedImpressionEffect` for screen view tracking
- Track `name_entered` event with `skipped` parameter (true if name was skipped)

### Analytics Events Tracked

| Event | Parameters | Trigger |
|-------|-----------|---------|
| `screen_view` | `screen_name`, `screen_class` | All 3 screens on load |
| `onboarding_started` | - | Onboarding screen loads |
| `onboarding_completed` | - | User clicks Skip or Get Started |
| `grade_selected` | `grade_level` | User selects K, 1st, or 2nd grade |
| `name_entered` | `skipped` | User enters name or clicks Skip/Continue |

### Technical Details

- **Circuit Integration**: Uses `LaunchedImpressionEffect` from CircuitX Effects
- **Metro DI**: AnalyticsService automatically injected via constructor
- **One-Time Tracking**: LaunchedImpressionEffect ensures events fire once per retention
- **Context Parameters**: Screen views include relevant context (e.g., is_from_settings)

## Testing

```bash
./gradlew formatKotlin
./gradlew assembleDebug
```

Results:
- ✅ Build successful
- ✅ Code formatted
- ✅ No compilation errors
- ✅ Analytics service properly injected

### Manual Testing Checklist
- [ ] Onboarding screen logs `onboarding_started` on first load
- [ ] Grade selection logs `grade_selected` with correct grade
- [ ] Name entry logs `name_entered` with correct skipped status
- [ ] All screen views appear in Firebase DebugView

## Dependencies

- Depends on: #144 (Analytics Interface) ✅ Merged
- Depends on: #145 (Firebase Analytics Service) ✅ Merged
- Blocks: #148 (Main App Screen Tracking)

## Checklist

- [x] Code follows project coding standards
- [x] Code formatted with `./gradlew formatKotlin`
- [x] Build passes (`./gradlew assembleDebug`)
- [x] CHANGELOG.md updated
- [x] Analytics service injected via Metro DI
- [x] LaunchedImpressionEffect used for screen tracking
- [x] All onboarding events tracked

## Next Steps

After this PR is merged:
- ✅ Onboarding analytics complete (#147)
- Ready to start: #148 (Main App Screen Tracking - 10 screens)

---

**Part of Analytics Implementation Epic (#153)**
**Onboarding Flow: 3 screens tracked with 5 events**