### PR TITLE
Analytics: Add tracking to 10 main app screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Track `name_entered` event with skipped status
   - Uses Circuit's `LaunchedImpressionEffect` for automatic screen view tracking
   - Implementation for Issue #147 (Onboarding Screen Tracking)
+- **Main App Analytics Tracking** - Added analytics tracking to 10 main application screens
+  - Track screen views for all main screens: Home, Stats, Badges, Settings, Operation Selector, Audio/Haptic Settings, Game Selection, Math Practice, Practice Results, Math Race
+  - Track key user interactions: operation selection, badge viewing, settings changes, audio/haptics toggles
+  - Math Practice screen includes operation type and problem count parameters
+  - Uses Circuit's `LaunchedImpressionEffect` for consistent screen view tracking across all screens
+  - Implementation for Issue #148 (Main App Screen Tracking)
 
 ### Fixed
 - **ANR when pressing system back from Settings and Games screens** - Fixed Application Not Responding issue when using system back button

--- a/app/src/main/java/dev/hossain/mathtutor/ui/badges/BadgesPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/badges/BadgesPresenter.kt
@@ -10,6 +10,10 @@ import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.domain.model.Badge
 import dev.hossain.mathtutor.domain.model.BadgeCategory
 import dev.hossain.mathtutor.domain.repository.BadgeProgress
@@ -31,6 +35,7 @@ class BadgesPresenter
     constructor(
         @Assisted private val navigator: Navigator,
         private val badgeRepository: BadgeRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<BadgesScreen.State> {
         @CircuitInject(BadgesScreen::class, AppScope::class)
         @AssistedFactory
@@ -40,6 +45,14 @@ class BadgesPresenter
 
         @Composable
         override fun present(): BadgesScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Badges",
+                    screenClass = BadgesScreen::class.java.name,
+                )
+            }
+
             // Track selected badge for detail dialog
             var selectedBadge by remember { mutableStateOf<Badge?>(null) }
 
@@ -70,6 +83,14 @@ class BadgesPresenter
                 when (event) {
                     is BadgesScreen.Event.BadgeClicked -> {
                         Timber.d("Badge clicked: ${event.badge.name} (${event.badge.id})")
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.BADGES_VIEWED,
+                            parameters =
+                                mapOf(
+                                    AnalyticsParam.BADGE_ID to event.badge.id,
+                                    AnalyticsParam.BADGE_NAME to event.badge.name,
+                                ),
+                        )
                         selectedBadge = event.badge
                     }
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionPresenter.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.getValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.domain.model.Game
 import dev.hossain.mathtutor.domain.model.GameStats
 import dev.hossain.mathtutor.domain.model.SessionStats
@@ -32,6 +34,7 @@ class GameSelectionPresenter
         @Assisted private val navigator: Navigator,
         private val gameRepository: GameRepository,
         private val sessionRepository: SessionRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<GameSelectionScreen.State> {
         @CircuitInject(GameSelectionScreen::class, AppScope::class)
         @AssistedFactory
@@ -41,6 +44,14 @@ class GameSelectionPresenter
 
         @Composable
         override fun present(): GameSelectionScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Game Selection",
+                    screenClass = GameSelectionScreen::class.java.name,
+                )
+            }
+
             // Collect overall stats to get total problems solved for unlock logic
             val sessionStats by sessionRepository.getOverallStats().collectAsState(
                 initial = SessionStats.EMPTY,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/HomePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/HomePresenter.kt
@@ -10,6 +10,10 @@ import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.audio.AudioService
 import dev.hossain.mathtutor.domain.model.DailyStreak
 import dev.hossain.mathtutor.domain.model.SessionStats
@@ -43,6 +47,7 @@ class HomePresenter
         private val badgeRepository: BadgeRepository,
         private val userProfileRepository: UserProfileRepository,
         private val audioService: AudioService,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<HomeScreen.State> {
         @CircuitInject(HomeScreen::class, AppScope::class)
         @AssistedFactory
@@ -52,6 +57,14 @@ class HomePresenter
 
         @Composable
         override fun present(): HomeScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Home",
+                    screenClass = HomeScreen::class.java.name,
+                )
+            }
+
             // Track music playing state
             var isMusicPlaying by remember { mutableStateOf(false) }
 
@@ -125,6 +138,14 @@ class HomePresenter
 
                     is HomeScreen.Event.ToggleMusicClicked -> {
                         isMusicPlaying = !isMusicPlaying
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.AUDIO_TOGGLED,
+                            parameters =
+                                mapOf(
+                                    AnalyticsParam.SETTING_NAME to "background_music",
+                                    AnalyticsParam.SETTING_VALUE to isMusicPlaying.toString(),
+                                ),
+                        )
                         if (isMusicPlaying) {
                             audioService.setMusicEnabled(true)
                             audioService.startBackgroundMusic()

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
@@ -10,6 +10,10 @@ import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.audio.AudioService
 import dev.hossain.mathtutor.domain.generator.AdaptiveProblemGenerator
 import dev.hossain.mathtutor.domain.generator.ProblemGenerator
@@ -58,6 +62,7 @@ class MathPracticePresenter
         private val updateStreakUseCase: UpdateStreakUseCase,
         private val audioService: AudioService,
         private val hapticService: HapticService,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<MathPracticeScreen.State> {
         @CircuitInject(MathPracticeScreen::class, AppScope::class)
         @AssistedFactory
@@ -70,6 +75,19 @@ class MathPracticePresenter
 
         @Composable
         override fun present(): MathPracticeScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Math Practice",
+                    screenClass = MathPracticeScreen::class.java.name,
+                    parameters =
+                        mapOf(
+                            AnalyticsParam.OPERATION_TYPE to screen.operation.name.lowercase(),
+                            AnalyticsParam.PROBLEM_COUNT to screen.problemCount,
+                        ),
+                )
+            }
+
             // Track session start time
             val sessionStartTime = remember { Instant.now() }
             // Use lifecycle-aware coroutine scope

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRacePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRacePresenter.kt
@@ -11,6 +11,10 @@ import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.audio.AudioService
 import dev.hossain.mathtutor.domain.generator.ProblemGenerator
 import dev.hossain.mathtutor.domain.model.Badge
@@ -57,6 +61,7 @@ class MathRacePresenter
         private val checkBadgeUnlocksUseCase: CheckBadgeUnlocksUseCase,
         private val audioService: AudioService,
         private val hapticService: HapticService,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<MathRaceScreen.State> {
         @CircuitInject(MathRaceScreen::class, AppScope::class)
         @AssistedFactory
@@ -83,6 +88,14 @@ class MathRacePresenter
 
         @Composable
         override fun present(): MathRaceScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Math Race",
+                    screenClass = MathRaceScreen::class.java.name,
+                )
+            }
+
             val coroutineScope = rememberCoroutineScope()
 
             // Game state

--- a/app/src/main/java/dev/hossain/mathtutor/ui/operationselector/OperationSelectorPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/operationselector/OperationSelectorPresenter.kt
@@ -7,6 +7,10 @@ import androidx.compose.runtime.getValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.domain.model.MathOperation
 import dev.hossain.mathtutor.domain.repository.SessionRepository
 import dev.hossain.mathtutor.ui.mathpractice.MathPracticeScreen
@@ -28,6 +32,7 @@ class OperationSelectorPresenter
     constructor(
         @Assisted private val navigator: Navigator,
         private val sessionRepository: SessionRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<OperationSelectorScreen.State> {
         @CircuitInject(OperationSelectorScreen::class, AppScope::class)
         @AssistedFactory
@@ -37,6 +42,14 @@ class OperationSelectorPresenter
 
         @Composable
         override fun present(): OperationSelectorScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Operation Selector",
+                    screenClass = OperationSelectorScreen::class.java.name,
+                )
+            }
+
             // Check if session history exists
             val overallStats by sessionRepository.getOverallStats().collectAsState(
                 initial = dev.hossain.mathtutor.domain.model.SessionStats.EMPTY,
@@ -54,6 +67,13 @@ class OperationSelectorPresenter
                 when (event) {
                     is OperationSelectorScreen.Event.OperationSelected -> {
                         Timber.d("OperationSelector: Operation selected - ${event.operation}")
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.OPERATION_SELECTED,
+                            parameters =
+                                mapOf(
+                                    AnalyticsParam.OPERATION_TYPE to event.operation.name.lowercase(),
+                                ),
+                        )
                         // Navigate to MathPracticeScreen with selected operation
                         navigator.goTo(
                             MathPracticeScreen(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/practiceresults/ResultsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/practiceresults/ResultsPresenter.kt
@@ -10,6 +10,9 @@ import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.domain.model.Badge
 import dev.hossain.mathtutor.domain.repository.UserProfileRepository
 import dev.hossain.mathtutor.domain.usecase.CheckBadgeUnlocksUseCase
@@ -38,6 +41,7 @@ class ResultsPresenter
         private val checkBadgeUnlocksUseCase: CheckBadgeUnlocksUseCase,
         private val updateStreakUseCase: UpdateStreakUseCase,
         private val userProfileRepository: UserProfileRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<ResultsScreen.State> {
         @CircuitInject(ResultsScreen::class, AppScope::class)
         @AssistedFactory
@@ -50,6 +54,14 @@ class ResultsPresenter
 
         @Composable
         override fun present(): ResultsScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Practice Results",
+                    screenClass = ResultsScreen::class.java.name,
+                )
+            }
+
             val coroutineScope = rememberCoroutineScope()
             var unlockedBadges by remember { mutableStateOf<List<Badge>>(emptyList()) }
             var showBadgeUnlock by remember { mutableStateOf(false) }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/AudioHapticSettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/AudioHapticSettingsPresenter.kt
@@ -8,6 +8,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.audio.AudioService
 import dev.hossain.mathtutor.data.UserPreferencesRepository
 import dev.hossain.mathtutor.haptic.HapticService
@@ -31,6 +35,7 @@ class AudioHapticSettingsPresenter
         private val userPreferencesRepository: UserPreferencesRepository,
         private val audioService: AudioService,
         private val hapticService: HapticService,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<AudioHapticSettingsScreen.State> {
         @CircuitInject(AudioHapticSettingsScreen::class, AppScope::class)
         @AssistedFactory
@@ -40,6 +45,14 @@ class AudioHapticSettingsPresenter
 
         @Composable
         override fun present(): AudioHapticSettingsScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Audio & Haptic Settings",
+                    screenClass = AudioHapticSettingsScreen::class.java.name,
+                )
+            }
+
             val scope = rememberCoroutineScope()
 
             // Collect all preferences
@@ -69,6 +82,14 @@ class AudioHapticSettingsPresenter
                 when (event) {
                     is AudioHapticSettingsScreen.Event.ToggleSoundEffects -> {
                         Timber.d("[AudioHapticSettings] Toggle sound effects - enabled=${event.enabled}")
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.AUDIO_TOGGLED,
+                            parameters =
+                                mapOf(
+                                    AnalyticsParam.SETTING_NAME to "sound_effects",
+                                    AnalyticsParam.SETTING_VALUE to event.enabled.toString(),
+                                ),
+                        )
                         audioService.setSoundEffectsEnabled(event.enabled)
                         scope.launch {
                             userPreferencesRepository.setSoundEffectsEnabled(event.enabled)
@@ -77,6 +98,14 @@ class AudioHapticSettingsPresenter
 
                     is AudioHapticSettingsScreen.Event.ToggleBackgroundMusic -> {
                         Timber.d("[AudioHapticSettings] Toggle background music - enabled=${event.enabled}")
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.AUDIO_TOGGLED,
+                            parameters =
+                                mapOf(
+                                    AnalyticsParam.SETTING_NAME to "background_music",
+                                    AnalyticsParam.SETTING_VALUE to event.enabled.toString(),
+                                ),
+                        )
                         audioService.setMusicEnabled(event.enabled)
                         if (event.enabled) {
                             audioService.startBackgroundMusic()
@@ -90,6 +119,14 @@ class AudioHapticSettingsPresenter
 
                     is AudioHapticSettingsScreen.Event.ToggleHaptics -> {
                         Timber.d("[AudioHapticSettings] Toggle haptics - enabled=${event.enabled}")
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.HAPTICS_TOGGLED,
+                            parameters =
+                                mapOf(
+                                    AnalyticsParam.SETTING_NAME to "haptics",
+                                    AnalyticsParam.SETTING_VALUE to event.enabled.toString(),
+                                ),
+                        )
                         hapticService.setHapticsEnabled(event.enabled)
                         scope.launch {
                             userPreferencesRepository.setHapticsEnabled(event.enabled)

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
@@ -11,6 +11,10 @@ import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsEvent
+import dev.hossain.mathtutor.analytics.AnalyticsParam
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.domain.model.GradeLevel
 import dev.hossain.mathtutor.domain.model.UserProfile
 import dev.hossain.mathtutor.domain.repository.UserProfileRepository
@@ -33,6 +37,7 @@ class SettingsPresenter
     constructor(
         @Assisted private val navigator: Navigator,
         private val userProfileRepository: UserProfileRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<SettingsScreen.State> {
         @CircuitInject(SettingsScreen::class, AppScope::class)
         @AssistedFactory
@@ -42,6 +47,14 @@ class SettingsPresenter
 
         @Composable
         override fun present(): SettingsScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Settings",
+                    screenClass = SettingsScreen::class.java.name,
+                )
+            }
+
             val scope = rememberCoroutineScope()
 
             // Collect user profile
@@ -76,6 +89,14 @@ class SettingsPresenter
 
                     is SettingsScreen.Event.ToggleAdaptiveDifficulty -> {
                         Timber.d("SettingsScreen: Toggle adaptive difficulty - enabled=${event.enabled}")
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.SETTINGS_CHANGED,
+                            parameters =
+                                mapOf(
+                                    AnalyticsParam.SETTING_NAME to "adaptive_difficulty",
+                                    AnalyticsParam.SETTING_VALUE to event.enabled.toString(),
+                                ),
+                        )
                         scope.launch {
                             userProfileRepository.updateAdaptiveDifficulty(event.enabled)
                         }
@@ -83,6 +104,14 @@ class SettingsPresenter
 
                     is SettingsScreen.Event.SaveName -> {
                         Timber.d("SettingsScreen: Saving name - ${event.name}")
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.SETTINGS_CHANGED,
+                            parameters =
+                                mapOf(
+                                    AnalyticsParam.SETTING_NAME to "user_name",
+                                    AnalyticsParam.SETTING_VALUE to (event.name ?: ""),
+                                ),
+                        )
                         showNameDialog = false
                         scope.launch {
                             if (profile != null) {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/stats/StatsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/stats/StatsPresenter.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.getValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuitx.effects.LaunchedImpressionEffect
+import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.domain.model.MathOperation
 import dev.hossain.mathtutor.domain.model.SessionStats
 import dev.hossain.mathtutor.domain.repository.SessionRepository
@@ -27,6 +29,7 @@ class StatsPresenter
     constructor(
         @Assisted private val navigator: Navigator,
         private val sessionRepository: SessionRepository,
+        private val analyticsService: AnalyticsService,
     ) : Presenter<StatsScreen.State> {
         @CircuitInject(StatsScreen::class, AppScope::class)
         @AssistedFactory
@@ -36,6 +39,14 @@ class StatsPresenter
 
         @Composable
         override fun present(): StatsScreen.State {
+            // Track screen view
+            LaunchedImpressionEffect {
+                analyticsService.logScreenView(
+                    screenName = "Stats",
+                    screenClass = StatsScreen::class.java.name,
+                )
+            }
+
             // Collect overall statistics
             val overallStats by sessionRepository.getOverallStats().collectAsState(
                 initial = SessionStats.EMPTY,


### PR DESCRIPTION
## Overview
Implements Issue #148 - Main App Screen Tracking

Adds comprehensive analytics tracking to all 10 main application screens using Circuit's `LaunchedImpressionEffect` for automatic screen view tracking.

## Changes

### Screen View Tracking (All 10 Screens)
✅ **HomePresenter** - Home screen with audio toggle tracking
✅ **StatsPresenter** - Statistics screen
✅ **BadgesPresenter** - Badges screen with badge view events
✅ **SettingsPresenter** - Settings screen with setting change events
✅ **OperationSelectorPresenter** - Operation selection with operation_selected event
✅ **AudioHapticSettingsPresenter** - Audio/Haptic settings with toggle events
✅ **GameSelectionPresenter** - Game selection hub
✅ **MathPracticePresenter** - Math practice with operation and problem count params
✅ **ResultsPresenter** - Practice results screen
✅ **MathRacePresenter** - Math Race game screen

### Key Events Tracked
- Screen views for all 10 screens (automatic via `LaunchedImpressionEffect`)
- `operation_selected` - When user selects a math operation
- `badges_viewed` - When user views badge details (with badge_id, badge_name)
- `settings_changed` - When user changes settings (adaptive difficulty, user name)
- `audio_toggled` - When user toggles audio settings (with setting name and value)
- `haptics_toggled` - When user toggles haptics (with setting value)

### Technical Details
- Injected `AnalyticsService` via Metro DI into all 10 presenters
- Used only predefined events/parameters from `AnalyticsConstants.kt`
- Follows established pattern from Issue #147 (Onboarding screens)
- All builds passing with no compilation errors

## Testing
- ✅ Build successful (`./gradlew assembleDebug`)
- ✅ Code formatted (`./gradlew formatKotlin`)
- ✅ All events use constants from `AnalyticsConstants.kt`

## Checklist
- [x] Added analytics tracking to all 10 main screens
- [x] Updated CHANGELOG.md
- [x] Followed Circuit UDF architecture patterns
- [x] Used Material 3 theme-aware components (no changes needed)
- [x] All builds passing

Closes #148