### PR TITLE
fix: Improve badge detail dialog display for locked badges

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/ui/component/BadgeDetailDialog.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/component/BadgeDetailDialog.kt
@@ -71,7 +71,7 @@ fun BadgeDetailDialog(
                 BadgeIcon(
                     badgeIcon = badge.icon,
                     contentDescription = badge.name,
-                    size = 80.dp,
+                    size = 120.dp,
                     colorFilter =
                         if (!badge.isUnlocked()) {
                             ColorFilter.tint(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f))

--- a/app/src/main/java/dev/hossain/mathtutor/ui/component/BadgeDetailDialog.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/component/BadgeDetailDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -71,6 +72,12 @@ fun BadgeDetailDialog(
                     badgeIcon = badge.icon,
                     contentDescription = badge.name,
                     size = 80.dp,
+                    colorFilter =
+                        if (!badge.isUnlocked()) {
+                            ColorFilter.tint(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f))
+                        } else {
+                            null
+                        },
                     modifier = Modifier.scale(scale),
                 )
 


### PR DESCRIPTION
## Summary
Improves the badge detail dialog by preventing locked badge reveals and increasing badge icon size for better visibility.

## Changes
- ✅ **Locked badge display**: Show locked badges as dimmed silhouettes (40% alpha tint) instead of revealing the full design
- ✅ **Icon size increase**: Increase badge icon from 80.dp to 120.dp for better prominence
- ✅ **Consistent appearance**: Matches the badge grid behavior where locked badges show only shape

## Problem Fixed
**Before:**
- Locked badges showed full design in greyscale in the dialog
- Badge details were revealed before unlock
- Icon was relatively small at 80.dp

**After:**
- Locked badges show as dimmed silhouettes (only shape visible)
- Badge design remains hidden until unlocked
- Larger 120.dp icon for better visual impact
- Consistent with badge grid display

## Technical Details
- Uses `ColorFilter.tint()` with `MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)`
- Same filter as used in BadgeGrid for consistency
- Applied conditionally only when `!badge.isUnlocked()`

## Testing
- ✅ Build successful
- ✅ Locked badges show as dimmed silhouettes
- ✅ Unlocked badges show full color at 120.dp
- ✅ Works in both light and dark modes
- ✅ Consistent appearance with badge grid