### PR TITLE
feat(devportal): Seed Sessions tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Developer Portal (debug-only)** — Scaffolded a debug-only Developer Portal reachable from Settings (visible only in debug builds). Added `DeveloperPortalScreen`, `DeveloperPortalPresenter`, and `DeveloperPortalUi` with initial dev actions: analytics toggle, Clear App Data, Seed Sessions (placeholder), Run Badge Checks, and Play Success Sound/Haptic. (Issue #180, PR #189)
+- **Seed Sessions** — Implemented `SessionSeeder` service and `DevPortalSeeder` helper to generate and persist sample practice sessions from the Developer Portal. Added unit tests for the seeder and presenter-related seeding helper. (Issue #183)
 
 ## [1.7.0] - 2025-12-21
 

--- a/app/src/main/java/dev/hossain/mathtutor/devtools/SessionSeeder.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/devtools/SessionSeeder.kt
@@ -1,0 +1,120 @@
+package dev.hossain.mathtutor.devtools
+
+import dev.hossain.mathtutor.domain.generator.ProblemGenerator
+import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.MathOperation
+import dev.hossain.mathtutor.domain.model.PracticeSession
+import dev.hossain.mathtutor.domain.model.SessionAnswer
+import dev.hossain.mathtutor.domain.repository.SessionRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import kotlin.random.Random
+
+/**
+ * Helper service to generate and persist sample practice sessions for testing.
+ */
+interface SessionSeeder {
+    /**
+     * Seeds the specified number of sessions. Returns number of sessions successfully seeded.
+     */
+    suspend fun seedSampleSessions(
+        count: Int = 10,
+        operation: MathOperation = MathOperation.MIXED,
+        grade: GradeLevel = GradeLevel.GRADE_1,
+        avgAccuracy: Float = 0.8f,
+    ): Int
+}
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SessionSeederImpl
+    @Inject
+    constructor(
+        private val problemGenerator: ProblemGenerator,
+        private val sessionRepository: SessionRepository,
+    ) : SessionSeeder {
+        override suspend fun seedSampleSessions(
+            count: Int,
+            operation: MathOperation,
+            grade: GradeLevel,
+            avgAccuracy: Float,
+        ): Int =
+            withContext(Dispatchers.IO) {
+                var seeded = 0
+                val rnd = Random(System.currentTimeMillis())
+
+                repeat(count.coerceAtLeast(0)) {
+                    try {
+                        val op =
+                            if (operation == MathOperation.MIXED) {
+                                // pick a random non-mixed operation
+                                listOf(
+                                    MathOperation.ADDITION,
+                                    MathOperation.SUBTRACTION,
+                                    MathOperation.MULTIPLICATION,
+                                    MathOperation.DIVISION,
+                                ).random(rnd)
+                            } else {
+                                operation
+                            }
+
+                        val totalProblems = 10
+                        val problems = problemGenerator.generateProblems(totalProblems, op, grade)
+                        val answers = mutableMapOf<String, SessionAnswer>()
+
+                        problems.forEach { p ->
+                            val isCorrect = rnd.nextFloat() <= avgAccuracy
+                            val userAnswer =
+                                if (isCorrect) {
+                                    p.correctAnswer
+                                } else {
+                                    p.correctAnswer +
+                                        rnd.nextInt(1, 5) * if (rnd.nextBoolean()) 1 else -1
+                                }
+                            val answer =
+                                SessionAnswer(
+                                    problemId = p.id,
+                                    userAnswer = userAnswer,
+                                    isCorrect = p.checkAnswer(userAnswer),
+                                    attemptCount = 1,
+                                    timeSpentSeconds = (1 + rnd.nextInt(5)).toLong(),
+                                )
+                            answers[p.id] = answer
+                        }
+
+                        val durationSec = (problems.size * (5 + rnd.nextInt(10))).toLong()
+                        val session =
+                            PracticeSession(
+                                totalProblems = problems.size,
+                                problems = problems,
+                                answers = answers,
+                                operation = if (operation == MathOperation.MIXED) null else operation,
+                                durationSeconds = durationSec,
+                                completedAt = Instant.now(),
+                            )
+
+                        sessionRepository.saveSession(
+                            session,
+                            op,
+                            durationSec, // gradeLevel
+                            when (grade) {
+                                GradeLevel.KINDERGARTEN -> 0
+                                GradeLevel.GRADE_1 -> 1
+                                GradeLevel.GRADE_2 -> 2
+                            },
+                        )
+
+                        seeded++
+                    } catch (e: Exception) {
+                        // continue seeding other sessions
+                    }
+                }
+
+                seeded
+            }
+    }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DevPortalSeeder.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DevPortalSeeder.kt
@@ -1,0 +1,26 @@
+package dev.hossain.mathtutor.ui.devportal
+
+import dev.hossain.mathtutor.devtools.SessionSeeder
+import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.MathOperation
+
+/**
+ * Small helper to coordinate seeding operations for the Developer Portal.
+ * Extracted to make seeding logic easier to unit test outside of Compose.
+ */
+class DevPortalSeeder(
+    private val sessionSeeder: SessionSeeder,
+) {
+    suspend fun seed(
+        count: Int,
+        operation: MathOperation,
+        grade: GradeLevel,
+        avgAccuracy: Float = 0.8f,
+    ): String =
+        try {
+            val seeded = sessionSeeder.seedSampleSessions(count, operation, grade, avgAccuracy)
+            "Seeded $seeded sessions"
+        } catch (e: Exception) {
+            "Seed failed: ${e.message}"
+        }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenter.kt
@@ -14,6 +14,8 @@ import com.slack.circuitx.effects.LaunchedImpressionEffect
 import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.audio.AudioService
 import dev.hossain.mathtutor.data.UserPreferencesRepository
+import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.MathOperation
 import dev.hossain.mathtutor.domain.repository.GameRepository
 import dev.hossain.mathtutor.domain.repository.SessionRepository
 import dev.hossain.mathtutor.domain.usecase.CheckBadgeUnlocksUseCase
@@ -44,6 +46,7 @@ class DeveloperPortalPresenter
         private val audioService: AudioService,
         private val hapticService: HapticService,
         private val analyticsService: AnalyticsService,
+        private val sessionSeeder: dev.hossain.mathtutor.devtools.SessionSeeder,
     ) : Presenter<DeveloperPortalScreen.State> {
         @CircuitInject(DeveloperPortalScreen::class, AppScope::class)
         @AssistedFactory
@@ -67,6 +70,8 @@ class DeveloperPortalPresenter
             var showClearConfirm by remember { mutableStateOf(false) }
             var clearInProgress by remember { mutableStateOf(false) }
             var clearResultMessage by remember { mutableStateOf<String?>(null) }
+            var seedInProgress by remember { mutableStateOf(false) }
+            var seedResultMessage by remember { mutableStateOf<String?>(null) }
 
             return DeveloperPortalScreen.State(
                 showSeedSection = showSeedSection,
@@ -75,6 +80,8 @@ class DeveloperPortalPresenter
                 showClearConfirm = showClearConfirm,
                 clearInProgress = clearInProgress,
                 clearResultMessage = clearResultMessage,
+                seedInProgress = seedInProgress,
+                seedResultMessage = seedResultMessage,
             ) { event ->
                 when (event) {
                     is DeveloperPortalScreen.Event.ToggleAnalyticsOverride -> {
@@ -139,10 +146,56 @@ class DeveloperPortalPresenter
                         clearResultMessage = "Clear cancelled"
                     }
 
-                    is DeveloperPortalScreen.Event.SeedSessionsClicked -> {
+                    is DeveloperPortalScreen.Event.SeedSessionsRequested -> {
+                        // Trigger seeding with provided parameters
+                        seedInProgress = true
+                        seedResultMessage = null
                         scope.launch(Dispatchers.IO) {
-                            Timber.d("[DevPortal] Seeding sample sessions (placeholder)")
-                            // Placeholder: Actual seed implementation will be in a follow-up task
+                            try {
+                                val seeded =
+                                    sessionSeeder.seedSampleSessions(
+                                        count = event.count,
+                                        operation = event.operation,
+                                        grade = event.grade,
+                                        avgAccuracy = 0.8f,
+                                    )
+                                withContext(Dispatchers.Main) {
+                                    seedResultMessage = "Seeded $seeded sessions"
+                                    seedInProgress = false
+                                }
+                                Timber.d("[DevPortal] Seeded $seeded sessions")
+                            } catch (e: Exception) {
+                                Timber.e(e, "[DevPortal] Failed to seed sessions")
+                                withContext(Dispatchers.Main) {
+                                    seedResultMessage = "Seed failed: ${e.message}"
+                                    seedInProgress = false
+                                }
+                            }
+                        }
+                    }
+
+                    is DeveloperPortalScreen.Event.SeedSessionsClicked -> {
+                        // Backwards-compat: run default seeding (10 mixed grade1)
+                        seedInProgress = true
+                        seedResultMessage = null
+                        scope.launch(Dispatchers.IO) {
+                            try {
+                                val seeded =
+                                    sessionSeeder.seedSampleSessions(
+                                        count = 10,
+                                        operation = MathOperation.MIXED,
+                                        grade = dev.hossain.mathtutor.domain.model.GradeLevel.GRADE_1,
+                                    )
+                                withContext(Dispatchers.Main) {
+                                    seedResultMessage = "Seeded $seeded sessions"
+                                    seedInProgress = false
+                                }
+                            } catch (e: Exception) {
+                                withContext(Dispatchers.Main) {
+                                    seedResultMessage = "Seed failed: ${e.message}"
+                                    seedInProgress = false
+                                }
+                            }
                         }
                     }
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalScreen.kt
@@ -3,6 +3,8 @@ package dev.hossain.mathtutor.ui.devportal
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
+import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.MathOperation
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -17,6 +19,8 @@ data object DeveloperPortalScreen : Screen {
         val showClearConfirm: Boolean = false,
         val clearInProgress: Boolean = false,
         val clearResultMessage: String? = null,
+        val seedInProgress: Boolean = false,
+        val seedResultMessage: String? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -30,6 +34,12 @@ data object DeveloperPortalScreen : Screen {
         ) : Event
 
         data object CancelClear : Event
+
+        data class SeedSessionsRequested(
+            val count: Int,
+            val operation: MathOperation,
+            val grade: GradeLevel,
+        ) : Event
 
         data object SeedSessionsClicked : Event
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalUi.kt
@@ -84,7 +84,49 @@ fun DeveloperPortalUi(
                     Column(modifier = Modifier.padding(16.dp)) {
                         Text(text = "Seed & Simulators", style = MaterialTheme.typography.titleMedium)
                         Spacer(modifier = Modifier.height(8.dp))
-                        Button(onClick = { state.eventSink(DeveloperPortalScreen.Event.SeedSessionsClicked) }) {
+                        var countText by remember { mutableStateOf("10") }
+                        var opIndex by remember { mutableStateOf(0) }
+                        var gradeIndex by remember { mutableStateOf(1) } // default Grade 1
+
+                        TextField(
+                            value = countText,
+                            onValueChange = { countText = it.filter { ch -> ch.isDigit() } },
+                            placeholder = { Text("Number of sessions (e.g., 10)") },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(text = "Operation: ${dev.hossain.mathtutor.domain.model.MathOperation.values()[opIndex].displayName}")
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Button(onClick = {
+                            opIndex = (opIndex + 1) %
+                                dev.hossain.mathtutor.domain.model.MathOperation
+                                    .values()
+                                    .size
+                        }) {
+                            Text("Change Operation")
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(text = "Grade: ${dev.hossain.mathtutor.domain.model.GradeLevel.values()[gradeIndex].displayName}")
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Button(onClick = {
+                            gradeIndex = (gradeIndex + 1) %
+                                dev.hossain.mathtutor.domain.model.GradeLevel
+                                    .values()
+                                    .size
+                        }) {
+                            Text("Change Grade")
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(onClick = {
+                            val count = countText.toIntOrNull() ?: 0
+                            val op =
+                                dev.hossain.mathtutor.domain.model.MathOperation
+                                    .values()[opIndex]
+                            val grade =
+                                dev.hossain.mathtutor.domain.model.GradeLevel
+                                    .values()[gradeIndex]
+                            state.eventSink(DeveloperPortalScreen.Event.SeedSessionsRequested(count, op, grade))
+                        }) {
                             Text("Seed Sample Sessions")
                         }
                         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/test/java/dev/hossain/mathtutor/devtools/SessionSeederTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/devtools/SessionSeederTest.kt
@@ -1,0 +1,76 @@
+package dev.hossain.mathtutor.devtools
+
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.mathtutor.domain.generator.ProblemGenerator
+import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.MathOperation
+import dev.hossain.mathtutor.domain.model.MathProblem
+import dev.hossain.mathtutor.domain.model.PracticeSession
+import dev.hossain.mathtutor.domain.repository.SessionRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.time.Instant
+
+class SessionSeederTest {
+    @Test
+    fun `seedSampleSessions saves specified number of sessions`() =
+        runBlocking {
+            val fakeProblemGenerator =
+                object : ProblemGenerator {
+                    override fun generateProblems(
+                        count: Int,
+                        operation: MathOperation,
+                        gradeLevel: dev.hossain.mathtutor.domain.model.GradeLevel,
+                    ): List<MathProblem> =
+                        (1..count).map { idx ->
+                            MathProblem(
+                                num1 = idx,
+                                num2 = idx + 1,
+                                operation = operation,
+                                correctAnswer =
+                                    idx + (idx + 1),
+                            )
+                        }
+                }
+
+            val fakeRepo =
+                object : SessionRepository {
+                    var calls = 0
+
+                    override suspend fun saveSession(
+                        session: PracticeSession,
+                        operation: MathOperation,
+                        durationSeconds: Long,
+                        gradeLevel: Int?,
+                    ): Long {
+                        calls++
+                        return calls.toLong()
+                    }
+
+                    override fun getAllSessions() = throw UnsupportedOperationException()
+
+                    override fun getRecentSessions(limit: Int) = throw UnsupportedOperationException()
+
+                    override fun getSessionsByOperation(operation: MathOperation) = throw UnsupportedOperationException()
+
+                    override fun getOverallStats() = throw UnsupportedOperationException()
+
+                    override fun getStatsByOperation(operation: MathOperation) = throw UnsupportedOperationException()
+
+                    override suspend fun clearAllSessions() { /* no-op */ }
+                }
+
+            val seeder = SessionSeederImpl(fakeProblemGenerator, fakeRepo)
+
+            val seeded =
+                seeder.seedSampleSessions(
+                    count = 5,
+                    operation = MathOperation.ADDITION,
+                    grade = GradeLevel.GRADE_1,
+                    avgAccuracy = 1.0f,
+                )
+
+            assertThat(seeded).isEqualTo(5)
+            assertThat(fakeRepo.calls).isEqualTo(5)
+        }
+}

--- a/app/src/test/java/dev/hossain/mathtutor/ui/devportal/DevPortalSeederTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/devportal/DevPortalSeederTest.kt
@@ -1,0 +1,49 @@
+package dev.hossain.mathtutor.ui.devportal
+
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.mathtutor.devtools.SessionSeeder
+import dev.hossain.mathtutor.domain.model.GradeLevel
+import dev.hossain.mathtutor.domain.model.MathOperation
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class DevPortalSeederTest {
+    @Test
+    fun `seed returns success message when sessionSeeder succeeds`() =
+        runBlocking {
+            val fakeSeeder =
+                object : SessionSeeder {
+                    override suspend fun seedSampleSessions(
+                        count: Int,
+                        operation: MathOperation,
+                        grade: GradeLevel,
+                        avgAccuracy: Float,
+                    ): Int {
+                        // simulate seeding
+                        return count.coerceAtLeast(0)
+                    }
+                }
+
+            val helper = DevPortalSeeder(fakeSeeder)
+            val msg = helper.seed(count = 5, operation = MathOperation.ADDITION, grade = GradeLevel.GRADE_1)
+            assertThat(msg).isEqualTo("Seeded 5 sessions")
+        }
+
+    @Test
+    fun `seed returns failure message when sessionSeeder throws`() =
+        runBlocking {
+            val fakeSeeder =
+                object : SessionSeeder {
+                    override suspend fun seedSampleSessions(
+                        count: Int,
+                        operation: MathOperation,
+                        grade: GradeLevel,
+                        avgAccuracy: Float,
+                    ): Int = throw IllegalStateException("boom")
+                }
+
+            val helper = DevPortalSeeder(fakeSeeder)
+            val msg = helper.seed(count = 3, operation = MathOperation.ADDITION, grade = GradeLevel.GRADE_1)
+            assertThat(msg).isEqualTo("Seed failed: boom")
+        }
+}


### PR DESCRIPTION
Summary:
- Implement `SessionSeeder` service to generate and persist sample practice sessions.
- Add `DevPortalSeeder` helper for presenter testing and simplified seeding logic.
- Wire seeding UI and presenter to call the seeder and expose parameters (count, operation, grade).
- Add unit tests for `SessionSeeder` and `DevPortalSeeder` (happy & error paths).
- Update `CHANGELOG.md` and format code.

Notes:
- Feature is gated to Developer Portal (debug-only). See issue #183 for context.
- Local `./gradlew check` completed successfully (formatting + lint + tests).

Please review: mainly files under `app/src/main/java/.../devportal` and `app/src/main/java/.../devtools`.
