### PR TITLE
feat(devportal): Force Badge Unlock + Run Badge Check (issue #184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Developer Portal (debug-only)** — Scaffolded a debug-only Developer Portal reachable from Settings (visible only in debug builds). Added `DeveloperPortalScreen`, `DeveloperPortalPresenter`, and `DeveloperPortalUi` with initial dev actions: analytics toggle, Clear App Data, Seed Sessions (placeholder), Run Badge Checks, and Play Success Sound/Haptic. (Issue #180, PR #189)
 - **Seed Sessions** — Implemented `SessionSeeder` service and `DevPortalSeeder` helper to generate and persist sample practice sessions from the Developer Portal. Added unit tests for the seeder and presenter-related seeding helper. (Issue #183)
+- **Force Badge Unlock** — Add per-badge "Force Unlock" control to Developer Portal to manually unlock badges for testing purposes. (Issue #184, PR #192)
 
 ## [1.7.0] - 2025-12-21
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenter.kt
@@ -121,6 +121,7 @@ class DeveloperPortalPresenter
                             }
                         }
                     }
+
                     is DeveloperPortalScreen.Event.ToggleAnalyticsOverride -> {
                         // Toggle analytics immediately (debug-only)
                         scope.launch(Dispatchers.IO) {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenter.kt
@@ -14,8 +14,10 @@ import com.slack.circuitx.effects.LaunchedImpressionEffect
 import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.audio.AudioService
 import dev.hossain.mathtutor.data.UserPreferencesRepository
+import dev.hossain.mathtutor.domain.model.Badge
 import dev.hossain.mathtutor.domain.model.GradeLevel
 import dev.hossain.mathtutor.domain.model.MathOperation
+import dev.hossain.mathtutor.domain.repository.BadgeRepository
 import dev.hossain.mathtutor.domain.repository.GameRepository
 import dev.hossain.mathtutor.domain.repository.SessionRepository
 import dev.hossain.mathtutor.domain.usecase.CheckBadgeUnlocksUseCase
@@ -42,6 +44,7 @@ class DeveloperPortalPresenter
         private val userPreferencesRepository: UserPreferencesRepository,
         private val sessionRepository: SessionRepository,
         private val gameRepository: GameRepository,
+        private val badgeRepository: BadgeRepository,
         private val checkBadgeUnlocksUseCase: CheckBadgeUnlocksUseCase,
         private val audioService: AudioService,
         private val hapticService: HapticService,
@@ -73,6 +76,17 @@ class DeveloperPortalPresenter
             var seedInProgress by remember { mutableStateOf(false) }
             var seedResultMessage by remember { mutableStateOf<String?>(null) }
 
+            var badges by remember { mutableStateOf<List<Badge>>(emptyList()) }
+            LaunchedEffect(Unit) {
+                // Collect badges from repository to display in UI
+                badgeRepository.getAllBadges().collect { list ->
+                    badges = list
+                }
+            }
+
+            var forceUnlockInProgress by remember { mutableStateOf(false) }
+            var forceUnlockResultMessage by remember { mutableStateOf<String?>(null) }
+
             return DeveloperPortalScreen.State(
                 showSeedSection = showSeedSection,
                 showDataOpsSection = showDataOpsSection,
@@ -82,8 +96,31 @@ class DeveloperPortalPresenter
                 clearResultMessage = clearResultMessage,
                 seedInProgress = seedInProgress,
                 seedResultMessage = seedResultMessage,
+                badges = badges,
+                forceUnlockInProgress = forceUnlockInProgress,
+                forceUnlockResultMessage = forceUnlockResultMessage,
             ) { event ->
                 when (event) {
+                    is DeveloperPortalScreen.Event.ForceUnlockBadge -> {
+                        forceUnlockInProgress = true
+                        forceUnlockResultMessage = null
+                        scope.launch(Dispatchers.IO) {
+                            try {
+                                badgeRepository.unlockBadge(event.badgeId)
+                                withContext(Dispatchers.Main) {
+                                    forceUnlockResultMessage = "Badge unlocked"
+                                    forceUnlockInProgress = false
+                                }
+                                Timber.d("[DevPortal] Force unlocked badge: ${event.badgeId}")
+                            } catch (e: Exception) {
+                                Timber.e(e, "[DevPortal] Failed to force unlock badge: ${event.badgeId}")
+                                withContext(Dispatchers.Main) {
+                                    forceUnlockResultMessage = "Unlock failed: ${e.message}"
+                                    forceUnlockInProgress = false
+                                }
+                            }
+                        }
+                    }
                     is DeveloperPortalScreen.Event.ToggleAnalyticsOverride -> {
                         // Toggle analytics immediately (debug-only)
                         scope.launch(Dispatchers.IO) {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalScreen.kt
@@ -50,7 +50,7 @@ data object DeveloperPortalScreen : Screen {
         data object ForceBadgeCheckClicked : Event
 
         data class ForceUnlockBadge(
-            val badgeId: String
+            val badgeId: String,
         ) : Event
 
         data object PlaySuccessSound : Event

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalScreen.kt
@@ -3,6 +3,7 @@ package dev.hossain.mathtutor.ui.devportal
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
+import dev.hossain.mathtutor.domain.model.Badge
 import dev.hossain.mathtutor.domain.model.GradeLevel
 import dev.hossain.mathtutor.domain.model.MathOperation
 import kotlinx.parcelize.Parcelize
@@ -21,6 +22,9 @@ data object DeveloperPortalScreen : Screen {
         val clearResultMessage: String? = null,
         val seedInProgress: Boolean = false,
         val seedResultMessage: String? = null,
+        val badges: List<Badge> = emptyList(),
+        val forceUnlockInProgress: Boolean = false,
+        val forceUnlockResultMessage: String? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -44,6 +48,10 @@ data object DeveloperPortalScreen : Screen {
         data object SeedSessionsClicked : Event
 
         data object ForceBadgeCheckClicked : Event
+
+        data class ForceUnlockBadge(
+            val badgeId: String
+        ) : Event
 
         data object PlaySuccessSound : Event
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalUi.kt
@@ -133,6 +133,38 @@ fun DeveloperPortalUi(
                         Button(onClick = { state.eventSink(DeveloperPortalScreen.Event.ForceBadgeCheckClicked) }) {
                             Text("Run Badge Checks")
                         }
+
+                        // Force unlock per-badge controls
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(text = "Force Unlock Badges", style = MaterialTheme.typography.bodyLarge)
+                        Spacer(modifier = Modifier.height(6.dp))
+                        if (state.badges.isEmpty()) {
+                            Text(text = "No badges available")
+                        } else {
+                            state.badges.forEach { badge ->
+                                Spacer(modifier = Modifier.height(6.dp))
+                                Column(modifier = Modifier.fillMaxWidth()) {
+                                    Text(text = badge.name)
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    Button(
+                                        onClick = { state.eventSink(DeveloperPortalScreen.Event.ForceUnlockBadge(badge.id)) },
+                                        enabled = !badge.isUnlocked(),
+                                    ) {
+                                        Text(if (badge.isUnlocked()) "Unlocked" else "Force Unlock")
+                                    }
+                                }
+                            }
+                        }
+
+                        // Show force unlock progress/result
+                        state.forceUnlockResultMessage?.let { msg ->
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(text = msg)
+                        }
+                        if (state.forceUnlockInProgress) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            CircularProgressIndicator()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Adds per-badge Force Unlock controls to the Developer Portal and presenter handling to call `BadgeRepository.unlockBadge`. Also continues to support running badge checks via `CheckBadgeUnlocksUseCase` (existing).\n\n- Developer Portal UI now lists badges with per-badge "Force Unlock" buttons (locked badges only).\n- Presenter collects badges from `BadgeRepository.getAllBadges()` and handles `ForceUnlockBadge` events, calling `unlockBadge` and exposing progress/result messages to UI.\n\nNo behavior changes to production code; all changes are debug-only UI and presenter wiring.\n\n

Closes issue #184.

Fixes #184 