### PR TITLE
Fix adaptive navigation double padding and add TopAppBar shadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **TopAppBar Shadow** - Added subtle drop shadow (4dp elevation) to all TopAppBar components across the app for better visual hierarchy and separation between the app bar and content
 - **Adaptive Layout Support** - Implemented tablet and adaptive layouts across all screens
   - Added Material 3 Adaptive dependencies for responsive layouts
   - Created WindowStateUtils for foldable device posture detection

--- a/app/src/main/java/dev/hossain/mathtutor/ui/badges/BadgesUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/badges/BadgesUi.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -97,6 +98,7 @@ fun BadgesUi(
                         )
                     }
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier.fillMaxSize(),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalUi.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import dev.zacsweers.metro.AppScope
@@ -41,7 +42,10 @@ fun DeveloperPortalUi(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("Developer Portal") })
+            TopAppBar(
+                title = { Text("Developer Portal") },
+                modifier = Modifier.shadow(elevation = 4.dp),
+            )
         },
         modifier = modifier.fillMaxSize(),
     ) { paddingValues ->

--- a/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/games/GameSelectionUi.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -96,6 +97,7 @@ fun GameSelectionUi(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
                         titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                     ),
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeUi.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -107,6 +108,7 @@ fun HomeUi(
                         )
                     }
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier.fillMaxSize(),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeUi.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -179,6 +180,7 @@ internal fun MathPracticeUi(
                         )
                     }
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier.fillMaxSize(),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceStartScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathrace/MathRaceStartScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -72,6 +73,7 @@ fun MathRaceStartScreen(
                         )
                     }
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/memorymatch/MemoryMatchUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/memorymatch/MemoryMatchUi.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -147,6 +148,7 @@ fun MemoryMatchStartScreen(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
                         titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                     ),
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier,
@@ -339,6 +341,7 @@ fun MemoryMatchGameScreen(
                     TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.surface,
                     ),
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier,
@@ -499,6 +502,7 @@ fun MemoryMatchResultsScreen(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
                         titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                     ),
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/navigation/AdaptiveNavigationWrapper.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/navigation/AdaptiveNavigationWrapper.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
@@ -117,11 +120,14 @@ private fun AppBottomNavigation(
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         // Main content takes remaining space
+        // consumeWindowInsets tells inner Scaffolds that bottom insets are already handled
+        // by the NavigationBar, preventing double bottom padding
         Box(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .weight(1f),
+                    .weight(1f)
+                    .consumeWindowInsets(WindowInsets.navigationBars),
         ) {
             content()
         }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/navigation/AdaptiveNavigationWrapper.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/navigation/AdaptiveNavigationWrapper.kt
@@ -1,9 +1,11 @@
 package dev.hossain.mathtutor.ui.navigation
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -17,7 +19,6 @@ import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.PermanentDrawerSheet
 import androidx.compose.material3.PermanentNavigationDrawer
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
@@ -102,6 +103,10 @@ fun AdaptiveNavigationWrapper(
 
 /**
  * Bottom navigation bar for compact (phone) devices.
+ *
+ * Note: We use Column instead of Scaffold here to avoid nested Scaffold issues.
+ * Each screen has its own Scaffold with topBar, so we just need to position
+ * the bottom navigation bar without adding extra padding.
  */
 @Composable
 private fun AppBottomNavigation(
@@ -110,41 +115,40 @@ private fun AppBottomNavigation(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    Scaffold(
-        bottomBar = {
-            NavigationBar {
-                TopLevelDestination.entries.forEach { destination ->
-                    val selected = currentDestination == destination
-                    NavigationBarItem(
-                        selected = selected,
-                        onClick = { onDestinationSelected(destination) },
-                        icon = {
-                            Icon(
-                                imageVector =
-                                    if (selected) {
-                                        destination.selectedIcon
-                                    } else {
-                                        destination.unselectedIcon
-                                    },
-                                contentDescription = destination.contentDescription,
-                            )
-                        },
-                        label = {
-                            Text(text = destination.label)
-                        },
-                    )
-                }
-            }
-        },
-        modifier = modifier,
-    ) { paddingValues ->
+    Column(modifier = modifier.fillMaxSize()) {
+        // Main content takes remaining space
         Box(
             modifier =
                 Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
+                    .fillMaxWidth()
+                    .weight(1f),
         ) {
             content()
+        }
+
+        // Bottom navigation bar
+        NavigationBar {
+            TopLevelDestination.entries.forEach { destination ->
+                val selected = currentDestination == destination
+                NavigationBarItem(
+                    selected = selected,
+                    onClick = { onDestinationSelected(destination) },
+                    icon = {
+                        Icon(
+                            imageVector =
+                                if (selected) {
+                                    destination.selectedIcon
+                                } else {
+                                    destination.unselectedIcon
+                                },
+                            contentDescription = destination.contentDescription,
+                        )
+                    },
+                    label = {
+                        Text(text = destination.label)
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -239,6 +240,7 @@ fun GradeSelectionUi(
                             )
                         }
                     },
+                    modifier = Modifier.shadow(elevation = 4.dp),
                 )
             }
         },

--- a/app/src/main/java/dev/hossain/mathtutor/ui/operationselector/OperationSelectorUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/operationselector/OperationSelectorUi.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -72,6 +73,7 @@ fun OperationSelectorUi(
                 title = {
                     Text("Math Time")
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier.fillMaxSize(),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/practiceresults/ResultsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/practiceresults/ResultsUi.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -79,6 +80,7 @@ fun ResultsUi(
                         )
                     }
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier.fillMaxSize(),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/AudioHapticSettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/AudioHapticSettingsUi.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
@@ -65,6 +66,7 @@ fun AudioHapticSettingsUi(
                         )
                     }
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier.fillMaxSize(),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -95,6 +96,7 @@ fun SettingsUi(
                         )
                     }
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier.fillMaxSize(),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/stats/StatsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/stats/StatsUi.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -81,6 +82,7 @@ fun StatsUi(
                         )
                     }
                 },
+                modifier = Modifier.shadow(elevation = 4.dp),
             )
         },
         modifier = modifier.fillMaxSize(),


### PR DESCRIPTION
## Summary

This PR fixes the extra spacing issue on phones after implementing adaptive layouts and adds visual improvements to TopAppBars.

## Changes

### Bug Fix: Double Padding on Phones
- **Problem**: After adding adaptive navigation, phone layouts had extra empty space at the top and bottom of screens
- **Root Cause**: Nested Scaffolds - `AdaptiveNavigationWrapper` used a Scaffold with bottomBar, while each screen also had its own Scaffold with topBar, causing double padding
- **Solution**: 
  - Changed `AppBottomNavigation` from using `Scaffold` to a simple `Column` layout
  - Added `consumeWindowInsets(WindowInsets.navigationBars)` to tell inner Scaffolds that bottom navigation bar insets are already handled

### Enhancement: TopAppBar Drop Shadow
- Added 4dp elevation shadow to all TopAppBar components across the app
- Provides better visual hierarchy and separation between app bar and content
- Applied to all 13 screens with TopAppBars:
  - HomeUi, GameSelectionUi, StatsUi, SettingsUi
  - AudioHapticSettingsUi, BadgesUi, OperationSelectorUi
  - MathPracticeUi, ResultsUi, MathRaceStartScreen
  - MemoryMatchUi (start, playing, results screens)
  - GradeSelectionScreen, DeveloperPortalUi

## Testing
- ✅ Verified on phone - no more extra spacing
- ✅ Verified on tablet - layouts work correctly
- ✅ Shadow visible and consistent across all screens