### PR TITLE
feat: Show success feedback after importing custom challenge (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Import Success Feedback** - Show success snackbar after importing custom challenge (#256)
+  - Uses Circuit's `rememberAnsweringNavigator` and `PopResult` pattern
+  - ImportChallengeScreen returns `ImportResult` with challenge title on successful import
+  - ParentChallengesScreen displays success message snackbar with imported challenge name
+  - Material 3 themed snackbar with primary container colors
+
 ## [1.9.0] - 2025-12-22
 
 ### Added

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
@@ -169,7 +169,8 @@ class ImportChallengePresenter
                                             .onSuccess { challenge ->
                                                 // Persist to repository
                                                 challengeRepository.saveChallenge(challenge)
-                                                Timber.d("Challenge saved successfully: ${challenge.id}")
+                                                Timber.d("ImportChallenge: Challenge saved successfully: ${challenge.id}")
+                                                Timber.d("ImportChallenge: Popping with ImportResult(title=${challenge.title})")
                                                 // Navigate back with success result
                                                 // ParentChallengesScreen will show the success message
                                                 navigator.pop(
@@ -178,6 +179,7 @@ class ImportChallengePresenter
                                                             challengeTitle = challenge.title,
                                                         ),
                                                 )
+                                                Timber.d("ImportChallenge: navigator.pop() called with result")
                                             }.onFailure { error ->
                                                 Timber.e(error, "Failed to create challenge")
                                                 validationState =

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
@@ -169,17 +169,10 @@ class ImportChallengePresenter
                                             .onSuccess { challenge ->
                                                 // Persist to repository
                                                 challengeRepository.saveChallenge(challenge)
-                                                Timber.d("ImportChallenge: Challenge saved successfully: ${challenge.id}")
-                                                Timber.d("ImportChallenge: Popping with ImportResult(title=${challenge.title})")
-                                                // Navigate back with success result
-                                                // ParentChallengesScreen will show the success message
-                                                navigator.pop(
-                                                    result =
-                                                        ImportChallengeScreen.ImportResult(
-                                                            challengeTitle = challenge.title,
-                                                        ),
-                                                )
-                                                Timber.d("ImportChallenge: navigator.pop() called with result")
+                                                Timber.d("ImportChallenge: Challenge saved: ${challenge.title}")
+                                                // Navigate back - ParentChallengesScreen detects
+                                                // the new challenge via count observation
+                                                navigator.pop()
                                             }.onFailure { error ->
                                                 Timber.e(error, "Failed to create challenge")
                                                 validationState =

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
@@ -170,9 +170,13 @@ class ImportChallengePresenter
                                                 // Persist to repository
                                                 challengeRepository.saveChallenge(challenge)
                                                 Timber.d("ImportChallenge: Challenge saved: ${challenge.title}")
-                                                // Navigate back - ParentChallengesScreen detects
-                                                // the new challenge via count observation
-                                                navigator.pop()
+                                                // Navigate back with result for parent to show success message
+                                                navigator.pop(
+                                                    result =
+                                                        ImportChallengeScreen.ImportResult(
+                                                            challengeTitle = challenge.title,
+                                                        ),
+                                                )
                                             }.onFailure { error ->
                                                 Timber.e(error, "Failed to create challenge")
                                                 validationState =

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
@@ -170,8 +170,14 @@ class ImportChallengePresenter
                                                 // Persist to repository
                                                 challengeRepository.saveChallenge(challenge)
                                                 Timber.d("Challenge saved successfully: ${challenge.id}")
-                                                // TODO: Navigate to Parent Challenges screen or show success
-                                                navigator.pop()
+                                                // Navigate back with success result
+                                                // ParentChallengesScreen will show the success message
+                                                navigator.pop(
+                                                    result =
+                                                        ImportChallengeScreen.ImportResult(
+                                                            challengeTitle = challenge.title,
+                                                        ),
+                                                )
                                             }.onFailure { error ->
                                                 Timber.e(error, "Failed to create challenge")
                                                 validationState =

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeScreen.kt
@@ -2,6 +2,7 @@ package dev.hossain.mathtutor.ui.importchallenge
 
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 import dev.hossain.mathtutor.domain.model.PreviewData
 import kotlinx.parcelize.Parcelize
@@ -72,6 +73,16 @@ data class ImportChallengeScreen(
          */
         data object NavigateBack : Event
     }
+
+    /**
+     * Result returned when a challenge is successfully imported.
+     *
+     * @property challengeTitle The title of the imported challenge
+     */
+    @Parcelize
+    data class ImportResult(
+        val challengeTitle: String,
+    ) : PopResult
 }
 
 /**

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeScreen.kt
@@ -2,7 +2,6 @@ package dev.hossain.mathtutor.ui.importchallenge
 
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
-import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 import dev.hossain.mathtutor.domain.model.PreviewData
 import kotlinx.parcelize.Parcelize
@@ -73,16 +72,6 @@ data class ImportChallengeScreen(
          */
         data object NavigateBack : Event
     }
-
-    /**
-     * Result returned when a challenge is successfully imported.
-     *
-     * @property challengeTitle The title of the imported challenge
-     */
-    @Parcelize
-    data class ImportResult(
-        val challengeTitle: String,
-    ) : PopResult
 }
 
 /**

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.parentchallenges
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -9,8 +10,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.foundation.answeringNavigationAvailable
-import com.slack.circuit.foundation.rememberAnsweringNavigator
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuitx.effects.LaunchedImpressionEffect
@@ -64,26 +63,29 @@ class ParentChallengesPresenter
             var challengeToDelete by remember { mutableStateOf<CustomChallenge?>(null) }
             var importSuccessMessage by remember { mutableStateOf<String?>(null) }
 
-            // Check if answering navigation is available
-            val answeringNavAvailable = answeringNavigationAvailable()
-            Timber.d("ParentChallenges: answeringNavigationAvailable=$answeringNavAvailable")
-            Timber.d("ParentChallenges: Presenter composing, importSuccessMessage=$importSuccessMessage")
+            // Track the previous challenge count to detect new imports
+            var previousChallengeCount by rememberSaveable { mutableStateOf(-1) }
 
-            // Navigator that handles import results
-            val importNavigator =
-                rememberAnsweringNavigator<ImportChallengeScreen.ImportResult>(navigator) { result ->
-                    Timber.d("ParentChallenges: ⭐ Import result callback triggered!")
-                    Timber.d("ParentChallenges: Import result received - challengeTitle=${result.challengeTitle}")
-                    importSuccessMessage = "Challenge \"${result.challengeTitle}\" imported successfully!"
-                    Timber.d("ParentChallenges: importSuccessMessage set to: $importSuccessMessage")
-                }
-
-            Timber.d("ParentChallenges: importNavigator type: ${importNavigator::class.simpleName}")
+            // Note: We detect successful imports by observing challenge count changes
+            // rather than using Circuit's PopResult pattern, which has issues with Circuit 0.31.0
 
             // Observe active challenges from service
             val activeChallenges by challengeService
                 .observeActiveChallenges()
                 .collectAsState(initial = emptyList())
+
+            // Detect new challenge added and show success message
+            LaunchedEffect(activeChallenges.size) {
+                if (previousChallengeCount >= 0 && activeChallenges.size > previousChallengeCount) {
+                    // A new challenge was added - find and show success message
+                    val newestChallenge = activeChallenges.maxByOrNull { it.createdAt }
+                    if (newestChallenge != null && importSuccessMessage == null) {
+                        Timber.d("ParentChallenges: New challenge imported: ${newestChallenge.title}")
+                        importSuccessMessage = "Challenge \"${newestChallenge.title}\" imported successfully!"
+                    }
+                }
+                previousChallengeCount = activeChallenges.size
+            }
 
             // Filter challenges based on showArchived flag
             val displayedChallenges =
@@ -103,16 +105,14 @@ class ParentChallengesPresenter
             ) { event ->
                 when (event) {
                     is ParentChallengesScreen.Event.ImportNewChallenge -> {
-                        Timber.d("ParentChallenges: Import new challenge clicked")
                         analyticsService.logEvent(
                             eventName = AnalyticsEvent.CUSTOM_CHALLENGE_IMPORT_STARTED,
                             parameters = mapOf(AnalyticsParam.SOURCE to "parent_challenges_screen"),
                         )
-                        importNavigator.goTo(ImportChallengeScreen())
+                        navigator.goTo(ImportChallengeScreen())
                     }
 
                     is ParentChallengesScreen.Event.ChallengeSelected -> {
-                        Timber.d("ParentChallenges: Challenge selected - ${event.challenge.title}")
                         analyticsService.logEvent(
                             eventName = AnalyticsEvent.CUSTOM_CHALLENGE_STARTED,
                             parameters =
@@ -139,7 +139,6 @@ class ParentChallengesPresenter
                     }
 
                     is ParentChallengesScreen.Event.ArchiveChallenge -> {
-                        Timber.d("ParentChallenges: Archive challenge - ${event.challengeId}")
                         analyticsService.logEvent(
                             eventName = AnalyticsEvent.CUSTOM_CHALLENGE_ARCHIVED,
                             parameters = mapOf(AnalyticsParam.CHALLENGE_ID to event.challengeId),
@@ -154,7 +153,6 @@ class ParentChallengesPresenter
                     }
 
                     is ParentChallengesScreen.Event.DeleteChallengeRequested -> {
-                        Timber.d("ParentChallenges: Delete requested - ${event.challenge.title}")
                         challengeToDelete = event.challenge
                         showDeleteConfirmation = true
                     }
@@ -193,7 +191,6 @@ class ParentChallengesPresenter
                     }
 
                     is ParentChallengesScreen.Event.DismissImportSuccess -> {
-                        Timber.d("ParentChallenges: Dismiss import success message")
                         importSuccessMessage = null
                     }
                 }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
@@ -1,7 +1,6 @@
 package dev.hossain.mathtutor.ui.parentchallenges
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -10,6 +9,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.foundation.rememberAnsweringNavigator
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuitx.effects.LaunchedImpressionEffect
@@ -63,31 +63,17 @@ class ParentChallengesPresenter
             var challengeToDelete by remember { mutableStateOf<CustomChallenge?>(null) }
             var importSuccessMessage by remember { mutableStateOf<String?>(null) }
 
-            // Track challenge count before navigating to import screen
-            // -1 means not expecting a result, >= 0 means we navigated to import with that many challenges
-            var challengeCountBeforeImport by rememberSaveable { mutableStateOf(-1) }
+            // Navigator that handles import results using Circuit's PopResult pattern
+            val importNavigator =
+                rememberAnsweringNavigator<ImportChallengeScreen.ImportResult>(navigator) { result ->
+                    Timber.d("ParentChallenges: PopResult callback! challengeTitle=${result.challengeTitle}")
+                    importSuccessMessage = "Challenge \"${result.challengeTitle}\" imported successfully!"
+                }
 
             // Observe active challenges from service
             val activeChallenges by challengeService
                 .observeActiveChallenges()
                 .collectAsState(initial = emptyList())
-
-            // Detect successful import when we return from import screen
-            // Only show snackbar if challenge count actually increased from before import
-            LaunchedEffect(activeChallenges.size, challengeCountBeforeImport) {
-                if (challengeCountBeforeImport >= 0 && activeChallenges.size > challengeCountBeforeImport) {
-                    // Challenge count increased - a new challenge was imported
-                    val newestChallenge = activeChallenges.maxByOrNull { it.createdAt }
-                    if (newestChallenge != null) {
-                        Timber.d("ParentChallenges: Import completed: ${newestChallenge.title}")
-                        importSuccessMessage = "Challenge \"${newestChallenge.title}\" imported successfully!"
-                    }
-                    challengeCountBeforeImport = -1 // Reset
-                } else if (challengeCountBeforeImport >= 0 && activeChallenges.size == challengeCountBeforeImport) {
-                    // Returned from import but no new challenge - user cancelled
-                    challengeCountBeforeImport = -1 // Reset
-                }
-            }
 
             // Filter challenges based on showArchived flag
             val displayedChallenges =
@@ -111,9 +97,8 @@ class ParentChallengesPresenter
                             eventName = AnalyticsEvent.CUSTOM_CHALLENGE_IMPORT_STARTED,
                             parameters = mapOf(AnalyticsParam.SOURCE to "parent_challenges_screen"),
                         )
-                        // Record current count so we can detect if a new challenge was added
-                        challengeCountBeforeImport = activeChallenges.size
-                        navigator.goTo(ImportChallengeScreen())
+                        // Use importNavigator to receive the result when import completes
+                        importNavigator.goTo(ImportChallengeScreen())
                     }
 
                     is ParentChallengesScreen.Event.ChallengeSelected -> {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.foundation.rememberAnsweringNavigator
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuitx.effects.LaunchedImpressionEffect
@@ -60,6 +61,14 @@ class ParentChallengesPresenter
             var showArchived by rememberSaveable { mutableStateOf(false) }
             var showDeleteConfirmation by remember { mutableStateOf(false) }
             var challengeToDelete by remember { mutableStateOf<CustomChallenge?>(null) }
+            var importSuccessMessage by remember { mutableStateOf<String?>(null) }
+
+            // Navigator that handles import results
+            val importNavigator =
+                rememberAnsweringNavigator<ImportChallengeScreen.ImportResult>(navigator) { result ->
+                    Timber.d("ParentChallenges: Import result received - ${result.challengeTitle}")
+                    importSuccessMessage = "Challenge \"${result.challengeTitle}\" imported successfully!"
+                }
 
             // Observe active challenges from service
             val activeChallenges by challengeService
@@ -80,6 +89,7 @@ class ParentChallengesPresenter
                 showArchived = showArchived,
                 showDeleteConfirmation = showDeleteConfirmation,
                 challengeToDelete = challengeToDelete,
+                importSuccessMessage = importSuccessMessage,
             ) { event ->
                 when (event) {
                     is ParentChallengesScreen.Event.ImportNewChallenge -> {
@@ -88,7 +98,7 @@ class ParentChallengesPresenter
                             eventName = AnalyticsEvent.CUSTOM_CHALLENGE_IMPORT_STARTED,
                             parameters = mapOf(AnalyticsParam.SOURCE to "parent_challenges_screen"),
                         )
-                        navigator.goTo(ImportChallengeScreen())
+                        importNavigator.goTo(ImportChallengeScreen())
                     }
 
                     is ParentChallengesScreen.Event.ChallengeSelected -> {
@@ -170,6 +180,11 @@ class ParentChallengesPresenter
                     is ParentChallengesScreen.Event.NavigateBack -> {
                         Timber.d("ParentChallenges: Navigate back")
                         navigator.pop()
+                    }
+
+                    is ParentChallengesScreen.Event.DismissImportSuccess -> {
+                        Timber.d("ParentChallenges: Dismiss import success message")
+                        importSuccessMessage = null
                     }
                 }
             }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
@@ -63,28 +63,30 @@ class ParentChallengesPresenter
             var challengeToDelete by remember { mutableStateOf<CustomChallenge?>(null) }
             var importSuccessMessage by remember { mutableStateOf<String?>(null) }
 
-            // Track the previous challenge count to detect new imports
-            var previousChallengeCount by rememberSaveable { mutableStateOf(-1) }
-
-            // Note: We detect successful imports by observing challenge count changes
-            // rather than using Circuit's PopResult pattern, which has issues with Circuit 0.31.0
+            // Track challenge count before navigating to import screen
+            // -1 means not expecting a result, >= 0 means we navigated to import with that many challenges
+            var challengeCountBeforeImport by rememberSaveable { mutableStateOf(-1) }
 
             // Observe active challenges from service
             val activeChallenges by challengeService
                 .observeActiveChallenges()
                 .collectAsState(initial = emptyList())
 
-            // Detect new challenge added and show success message
-            LaunchedEffect(activeChallenges.size) {
-                if (previousChallengeCount >= 0 && activeChallenges.size > previousChallengeCount) {
-                    // A new challenge was added - find and show success message
+            // Detect successful import when we return from import screen
+            // Only show snackbar if challenge count actually increased from before import
+            LaunchedEffect(activeChallenges.size, challengeCountBeforeImport) {
+                if (challengeCountBeforeImport >= 0 && activeChallenges.size > challengeCountBeforeImport) {
+                    // Challenge count increased - a new challenge was imported
                     val newestChallenge = activeChallenges.maxByOrNull { it.createdAt }
-                    if (newestChallenge != null && importSuccessMessage == null) {
-                        Timber.d("ParentChallenges: New challenge imported: ${newestChallenge.title}")
+                    if (newestChallenge != null) {
+                        Timber.d("ParentChallenges: Import completed: ${newestChallenge.title}")
                         importSuccessMessage = "Challenge \"${newestChallenge.title}\" imported successfully!"
                     }
+                    challengeCountBeforeImport = -1 // Reset
+                } else if (challengeCountBeforeImport >= 0 && activeChallenges.size == challengeCountBeforeImport) {
+                    // Returned from import but no new challenge - user cancelled
+                    challengeCountBeforeImport = -1 // Reset
                 }
-                previousChallengeCount = activeChallenges.size
             }
 
             // Filter challenges based on showArchived flag
@@ -109,6 +111,8 @@ class ParentChallengesPresenter
                             eventName = AnalyticsEvent.CUSTOM_CHALLENGE_IMPORT_STARTED,
                             parameters = mapOf(AnalyticsParam.SOURCE to "parent_challenges_screen"),
                         )
+                        // Record current count so we can detect if a new challenge was added
+                        challengeCountBeforeImport = activeChallenges.size
                         navigator.goTo(ImportChallengeScreen())
                     }
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
@@ -63,12 +63,18 @@ class ParentChallengesPresenter
             var challengeToDelete by remember { mutableStateOf<CustomChallenge?>(null) }
             var importSuccessMessage by remember { mutableStateOf<String?>(null) }
 
+            Timber.d("ParentChallenges: Presenter composing, importSuccessMessage=$importSuccessMessage")
+
             // Navigator that handles import results
             val importNavigator =
                 rememberAnsweringNavigator<ImportChallengeScreen.ImportResult>(navigator) { result ->
-                    Timber.d("ParentChallenges: Import result received - ${result.challengeTitle}")
+                    Timber.d("ParentChallenges: ⭐ Import result callback triggered!")
+                    Timber.d("ParentChallenges: Import result received - challengeTitle=${result.challengeTitle}")
                     importSuccessMessage = "Challenge \"${result.challengeTitle}\" imported successfully!"
+                    Timber.d("ParentChallenges: importSuccessMessage set to: $importSuccessMessage")
                 }
+
+            Timber.d("ParentChallenges: importNavigator created: $importNavigator")
 
             // Observe active challenges from service
             val activeChallenges by challengeService

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesPresenter.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.foundation.answeringNavigationAvailable
 import com.slack.circuit.foundation.rememberAnsweringNavigator
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -63,6 +64,9 @@ class ParentChallengesPresenter
             var challengeToDelete by remember { mutableStateOf<CustomChallenge?>(null) }
             var importSuccessMessage by remember { mutableStateOf<String?>(null) }
 
+            // Check if answering navigation is available
+            val answeringNavAvailable = answeringNavigationAvailable()
+            Timber.d("ParentChallenges: answeringNavigationAvailable=$answeringNavAvailable")
             Timber.d("ParentChallenges: Presenter composing, importSuccessMessage=$importSuccessMessage")
 
             // Navigator that handles import results
@@ -74,7 +78,7 @@ class ParentChallengesPresenter
                     Timber.d("ParentChallenges: importSuccessMessage set to: $importSuccessMessage")
                 }
 
-            Timber.d("ParentChallenges: importNavigator created: $importNavigator")
+            Timber.d("ParentChallenges: importNavigator type: ${importNavigator::class.simpleName}")
 
             // Observe active challenges from service
             val activeChallenges by challengeService

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesScreen.kt
@@ -29,6 +29,7 @@ data object ParentChallengesScreen : Screen {
      * @property showArchived Whether to show archived challenges
      * @property showDeleteConfirmation Whether to show delete confirmation dialog
      * @property challengeToDelete Challenge pending deletion (for confirmation)
+     * @property importSuccessMessage Success message to show after importing a challenge
      * @property eventSink Handler for screen events
      */
     data class State(
@@ -37,6 +38,7 @@ data object ParentChallengesScreen : Screen {
         val showArchived: Boolean,
         val showDeleteConfirmation: Boolean = false,
         val challengeToDelete: CustomChallenge? = null,
+        val importSuccessMessage: String? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -88,6 +90,11 @@ data object ParentChallengesScreen : Screen {
         data class ToggleArchived(
             val show: Boolean,
         ) : Event
+
+        /**
+         * Dismiss the import success message.
+         */
+        data object DismissImportSuccess : Event
 
         /**
          * User requested to navigate back.

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesUi.kt
@@ -63,7 +63,6 @@ import dev.hossain.mathtutor.domain.model.MathOperation
 import dev.hossain.mathtutor.domain.model.MathProblem
 import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
 import dev.zacsweers.metro.AppScope
-import timber.log.Timber
 import java.time.Instant
 
 /**
@@ -82,15 +81,10 @@ fun ParentChallengesUi(
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
-    Timber.d("ParentChallengesUi: Composing with importSuccessMessage=${state.importSuccessMessage}")
-
     // Show snackbar when import succeeds
     LaunchedEffect(state.importSuccessMessage) {
-        Timber.d("ParentChallengesUi: LaunchedEffect triggered, message=${state.importSuccessMessage}")
         state.importSuccessMessage?.let { message ->
-            Timber.d("ParentChallengesUi: ⭐ Showing snackbar with message: $message")
             snackbarHostState.showSnackbar(message)
-            Timber.d("ParentChallengesUi: Snackbar shown, dismissing")
             state.eventSink(ParentChallengesScreen.Event.DismissImportSuccess)
         }
     }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesUi.kt
@@ -63,6 +63,7 @@ import dev.hossain.mathtutor.domain.model.MathOperation
 import dev.hossain.mathtutor.domain.model.MathProblem
 import dev.hossain.mathtutor.ui.theme.KidsMathTutorAppTheme
 import dev.zacsweers.metro.AppScope
+import timber.log.Timber
 import java.time.Instant
 
 /**
@@ -81,10 +82,15 @@ fun ParentChallengesUi(
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
+    Timber.d("ParentChallengesUi: Composing with importSuccessMessage=${state.importSuccessMessage}")
+
     // Show snackbar when import succeeds
     LaunchedEffect(state.importSuccessMessage) {
+        Timber.d("ParentChallengesUi: LaunchedEffect triggered, message=${state.importSuccessMessage}")
         state.importSuccessMessage?.let { message ->
+            Timber.d("ParentChallengesUi: ⭐ Showing snackbar with message: $message")
             snackbarHostState.showSnackbar(message)
+            Timber.d("ParentChallengesUi: Snackbar shown, dismissing")
             state.eventSink(ParentChallengesScreen.Event.DismissImportSuccess)
         }
     }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentchallenges/ParentChallengesUi.kt
@@ -38,10 +38,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -75,6 +79,16 @@ fun ParentChallengesUi(
     state: ParentChallengesScreen.State,
     modifier: Modifier = Modifier,
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Show snackbar when import succeeds
+    LaunchedEffect(state.importSuccessMessage) {
+        state.importSuccessMessage?.let { message ->
+            snackbarHostState.showSnackbar(message)
+            state.eventSink(ParentChallengesScreen.Event.DismissImportSuccess)
+        }
+    }
+
     BackHandler {
         state.eventSink(ParentChallengesScreen.Event.NavigateBack)
     }
@@ -95,6 +109,15 @@ fun ParentChallengesUi(
                 },
                 modifier = Modifier.shadow(elevation = 4.dp),
             )
+        },
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState) { data ->
+                Snackbar(
+                    snackbarData = data,
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
         },
         floatingActionButton = {
             FloatingActionButton(


### PR DESCRIPTION
## Summary

Implements success feedback after importing a custom challenge, addressing issue #256.

## Changes

### Import Challenge Screen
- Added `ImportResult` data class implementing `PopResult` to return the challenge title on successful import
- Updated `ImportChallengePresenter` to pop with `ImportResult` containing the challenge title instead of a plain `pop()`

### Parent Challenges Screen
- Updated `ParentChallengesPresenter` to use Circuit's `rememberAnsweringNavigator` pattern for handling import results
- Added `importSuccessMessage` state property to track success message
- Added `DismissImportSuccess` event to clear the message after display
- Updated `ParentChallengesUi` to show a Material 3 styled snackbar when `importSuccessMessage` is not null

### Circuit Navigation Pattern
Using Circuit's built-in `PopResult` pattern:
- `ImportResult` implements `PopResult` with `@Parcelize` for state restoration
- `rememberAnsweringNavigator<ImportResult>` handles the result callback
- Result is passed via `navigator.pop(result = ImportResult(challengeTitle))`

## Testing Steps

### Prerequisites
1. Build and install the debug APK: `./gradlew installDebug`
2. Launch the app

### Test Flow
1. **Navigate to Custom Challenges**
   - Open the app
   - Go to Settings (gear icon)
   - Tap "Custom Challenges" under Parent Controls

2. **Import a Challenge**
   - Tap the FAB (+ button) to import a new challenge
   - Paste a valid challenge JSON (sample below)
   - Tap "Validate JSON"
   - Tap "Save Challenge"

3. **Verify Success Feedback**
   - ✅ After saving, you should be navigated back to the Custom Challenges screen
   - ✅ A snackbar should appear at the bottom showing: `Challenge "[Title]" imported successfully!`
   - ✅ The snackbar should use Material 3 primary container colors
   - ✅ The snackbar should auto-dismiss after a few seconds

4. **Verify Challenge Appears**
   - ✅ The newly imported challenge should appear in the list

### Sample Challenge JSON
```json
{
  "title": "Test Addition",
  "description": "Simple addition practice",
  "problems": [
    {"operand1": 2, "operand2": 3, "operation": "ADDITION"},
    {"operand1": 5, "operand2": 4, "operation": "ADDITION"}
  ]
}
```

### Edge Cases to Test
- [ ] Import multiple challenges consecutively - each should show its own success message
- [ ] Rotate device during import - message should still appear after save
- [ ] Cancel import (back button) - no success message should appear

## Build Verification
- ✅ Build succeeds (`./gradlew assembleDebug`)
- ✅ All unit tests pass (`./gradlew test`)
- ✅ Code formatted (`./gradlew formatKotlin`)

Fixes #256