### PR TITLE
Hide Settings from global navigation

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/ui/navigation/AdaptiveNavigationWrapper.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/navigation/AdaptiveNavigationWrapper.kt
@@ -137,39 +137,41 @@ private fun AppBottomNavigation(
 
         // Bottom navigation bar
         NavigationBar {
-            TopLevelDestination.entries.forEach { destination ->
-                val selected = currentDestination == destination
-                val colors = destination.getNavigationItemColors()
+            TopLevelDestination.entries
+                .filter { it != TopLevelDestination.SETTINGS } // Settings is accessible from home screen
+                .forEach { destination ->
+                    val selected = currentDestination == destination
+                    val colors = destination.getNavigationItemColors()
 
-                NavigationBarItem(
-                    selected = selected,
-                    onClick = { onDestinationSelected(destination) },
-                    icon = {
-                        Icon(
-                            imageVector =
-                                if (selected) {
-                                    destination.selectedIcon
-                                } else {
-                                    destination.unselectedIcon
-                                },
-                            contentDescription = destination.contentDescription,
-                        )
-                    },
-                    label = {
-                        Text(text = destination.label)
-                    },
-                    colors =
-                        if (selected) {
-                            NavigationBarItemDefaults.colors(
-                                selectedIconColor = colors.contentColor,
-                                selectedTextColor = MaterialTheme.colorScheme.onSurface,
-                                indicatorColor = colors.containerColor,
+                    NavigationBarItem(
+                        selected = selected,
+                        onClick = { onDestinationSelected(destination) },
+                        icon = {
+                            Icon(
+                                imageVector =
+                                    if (selected) {
+                                        destination.selectedIcon
+                                    } else {
+                                        destination.unselectedIcon
+                                    },
+                                contentDescription = destination.contentDescription,
                             )
-                        } else {
-                            NavigationBarItemDefaults.colors()
                         },
-                )
-            }
+                        label = {
+                            Text(text = destination.label)
+                        },
+                        colors =
+                            if (selected) {
+                                NavigationBarItemDefaults.colors(
+                                    selectedIconColor = colors.contentColor,
+                                    selectedTextColor = MaterialTheme.colorScheme.onSurface,
+                                    indicatorColor = colors.containerColor,
+                                )
+                            } else {
+                                NavigationBarItemDefaults.colors()
+                            },
+                    )
+                }
         }
     }
 }
@@ -188,39 +190,41 @@ private fun AppNavigationRail(
         NavigationRail(
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
         ) {
-            TopLevelDestination.entries.forEach { destination ->
-                val selected = currentDestination == destination
-                val colors = destination.getNavigationItemColors()
+            TopLevelDestination.entries
+                .filter { it != TopLevelDestination.SETTINGS } // Settings is accessible from home screen
+                .forEach { destination ->
+                    val selected = currentDestination == destination
+                    val colors = destination.getNavigationItemColors()
 
-                NavigationRailItem(
-                    selected = selected,
-                    onClick = { onDestinationSelected(destination) },
-                    icon = {
-                        Icon(
-                            imageVector =
-                                if (selected) {
-                                    destination.selectedIcon
-                                } else {
-                                    destination.unselectedIcon
-                                },
-                            contentDescription = destination.contentDescription,
-                        )
-                    },
-                    label = {
-                        Text(text = destination.label)
-                    },
-                    colors =
-                        if (selected) {
-                            NavigationRailItemDefaults.colors(
-                                selectedIconColor = colors.contentColor,
-                                selectedTextColor = MaterialTheme.colorScheme.onSurface,
-                                indicatorColor = colors.containerColor,
+                    NavigationRailItem(
+                        selected = selected,
+                        onClick = { onDestinationSelected(destination) },
+                        icon = {
+                            Icon(
+                                imageVector =
+                                    if (selected) {
+                                        destination.selectedIcon
+                                    } else {
+                                        destination.unselectedIcon
+                                    },
+                                contentDescription = destination.contentDescription,
                             )
-                        } else {
-                            NavigationRailItemDefaults.colors()
                         },
-                )
-            }
+                        label = {
+                            Text(text = destination.label)
+                        },
+                        colors =
+                            if (selected) {
+                                NavigationRailItemDefaults.colors(
+                                    selectedIconColor = colors.contentColor,
+                                    selectedTextColor = MaterialTheme.colorScheme.onSurface,
+                                    indicatorColor = colors.containerColor,
+                                )
+                            } else {
+                                NavigationRailItemDefaults.colors()
+                            },
+                    )
+                }
         }
         // Main content
         Box(
@@ -254,40 +258,42 @@ private fun AppPermanentNavigationDrawer(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                TopLevelDestination.entries.forEach { destination ->
-                    val selected = currentDestination == destination
-                    val colors = destination.getNavigationItemColors()
+                TopLevelDestination.entries
+                    .filter { it != TopLevelDestination.SETTINGS } // Settings is accessible from home screen
+                    .forEach { destination ->
+                        val selected = currentDestination == destination
+                        val colors = destination.getNavigationItemColors()
 
-                    NavigationDrawerItem(
-                        selected = selected,
-                        onClick = { onDestinationSelected(destination) },
-                        icon = {
-                            Icon(
-                                imageVector =
-                                    if (selected) {
-                                        destination.selectedIcon
-                                    } else {
-                                        destination.unselectedIcon
-                                    },
-                                contentDescription = destination.contentDescription,
-                            )
-                        },
-                        label = {
-                            Text(text = destination.label)
-                        },
-                        colors =
-                            if (selected) {
-                                NavigationDrawerItemDefaults.colors(
-                                    selectedIconColor = colors.contentColor,
-                                    selectedTextColor = colors.contentColor,
-                                    selectedContainerColor = colors.containerColor,
+                        NavigationDrawerItem(
+                            selected = selected,
+                            onClick = { onDestinationSelected(destination) },
+                            icon = {
+                                Icon(
+                                    imageVector =
+                                        if (selected) {
+                                            destination.selectedIcon
+                                        } else {
+                                            destination.unselectedIcon
+                                        },
+                                    contentDescription = destination.contentDescription,
                                 )
-                            } else {
-                                NavigationDrawerItemDefaults.colors()
                             },
-                        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-                    )
-                }
+                            label = {
+                                Text(text = destination.label)
+                            },
+                            colors =
+                                if (selected) {
+                                    NavigationDrawerItemDefaults.colors(
+                                        selectedIconColor = colors.contentColor,
+                                        selectedTextColor = colors.contentColor,
+                                        selectedContainerColor = colors.containerColor,
+                                    )
+                                } else {
+                                    NavigationDrawerItemDefaults.colors()
+                                },
+                            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                        )
+                    }
             }
         },
         modifier = modifier,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
@@ -87,6 +87,20 @@ fun SettingsUi(
     state: SettingsScreen.State,
     modifier: Modifier = Modifier,
 ) {
+    /*
+     * IMPORTANT: Explicit BackHandler to prevent ANR on system back button press.
+     *
+     * Without this BackHandler, pressing the system back button causes a 5+ second freeze
+     * with 97-110% CPU usage on the main thread, triggering an ANR (Application Not Responding).
+     * The BackHandler ensures immediate navigation response by handling the back event directly
+     * and triggering navigation without blocking the UI thread.
+     *
+     * See: PR #142 for details on the ANR issue and fix.
+     */
+    BackHandler {
+        state.eventSink(SettingsScreen.Event.BackClicked)
+    }
+
     Scaffold(
         topBar = {
             FeatureTopAppBar(
@@ -94,6 +108,14 @@ fun SettingsUi(
                     Text("Settings")
                 },
                 feature = TopBarFeature.SETTINGS,
+                navigationIcon = {
+                    IconButton(onClick = { state.eventSink(SettingsScreen.Event.BackClicked) }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
             )
         },
         modifier = modifier.fillMaxSize(),


### PR DESCRIPTION
## Overview
Hide Settings from the global navigation (bottom nav, nav rail, nav drawer) while keeping the Settings screen accessible from the home screen.

## Changes Made

### 1. Filter out SETTINGS from navigation displays
- **File**: `AdaptiveNavigationWrapper.kt`
- **Changes**: Added filter to exclude `TopLevelDestination.SETTINGS` from all three navigation surfaces:
  - Bottom Navigation Bar (phone/small devices)
  - Navigation Rail (tablet/medium devices)
  - Navigation Drawer (large devices)
- Settings enum and colors remain available for future use

### 2. Re-add back navigation to Settings screen
- **File**: `SettingsUi.kt`
- **Changes**:
  - Added `BackHandler` to handle system back button press and prevent ANR
  - Added back button to TopAppBar using `navigationIcon` parameter
  - Users can now navigate back from Settings to the previous screen

## Rationale
- Settings is more easily accessible from the home screen
- Reduces clutter in main navigation with 3 primary destinations (Home, Games, Parents)
- Settings enum and colors are preserved for future use if navigation structure changes
- Back navigation ensures users can return from Settings easily

## Testing
- ✅ Build succeeds (all 123 tasks)
- ✅ All unit tests pass
- ✅ No compilation warnings related to these changes