### PR TITLE
fix: NullPointerException in MathPracticePresenter.generateProblemsWithUniqueStrings()

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
@@ -242,8 +242,8 @@ class MathPracticePresenter
                                     screen.problemCount,
                                 )
                             }
-                        customChallengeTitle = challenge.title
                         actualGradeLevel = grade // Use user's grade for custom challenges
+                        customChallengeTitle = challenge.title
                         Timber.d(
                             "Loaded ${problems.size} problems from custom challenge '${challenge.title}' (type: ${challenge.type})",
                         )
@@ -256,13 +256,14 @@ class MathPracticePresenter
                                 operation = screen.operation,
                                 gradeLevel = grade,
                             )
+                        // Set grade level before calling generateProblemsWithUniqueStrings
+                        actualGradeLevel = grade
                         // Validate generated problems for unique strings
                         problems =
                             generateProblemsWithUniqueStrings(
                                 generatedProblems,
                                 screen.problemCount,
                             )
-                        actualGradeLevel = grade
                     }
                 } else if (isAdaptiveEnabled) {
                     // Use adaptive problem generator
@@ -272,13 +273,14 @@ class MathPracticePresenter
                             operation = screen.operation,
                             baseGradeLevel = grade,
                         )
+                    // Set grade level before calling generateProblemsWithUniqueStrings
+                    actualGradeLevel = result.actualGradeLevel
                     // Validate adaptive problems for unique strings
                     problems =
                         generateProblemsWithUniqueStrings(
                             result.problems,
                             screen.problemCount,
                         )
-                    actualGradeLevel = result.actualGradeLevel
                     difficultyAdjustment = result.adjustment
                     if (result.wasAdjusted) {
                         showDifficultyChangeNotice = true
@@ -304,13 +306,14 @@ class MathPracticePresenter
                             operation = screen.operation,
                             gradeLevel = grade,
                         )
+                    // Set grade level before calling generateProblemsWithUniqueStrings
+                    actualGradeLevel = grade
                     // Validate standard problems for unique strings
                     problems =
                         generateProblemsWithUniqueStrings(
                             generatedProblems,
                             screen.problemCount,
                         )
-                    actualGradeLevel = grade
                 }
                 Timber.d(
                     "Generated ${problems.size} problems for grade $actualGradeLevel " +


### PR DESCRIPTION
## Issue Description

The app is crashing with a `NullPointerException` in the Math Practice screen whenever a user attempts to start a practice session. The crash occurs in `MathPracticePresenter.present$generateProblemsWithUniqueStrings()` at line 82 (obfuscated stack trace from release build).

**Stack Trace:**
```
java.lang.NullPointerException
	at dev.hossain.mathtutor.ui.mathpractice.MathPracticePresenter.present$generateProblemsWithUniqueStrings(...)
	at dev.hossain.mathtutor.ui.mathpractice.MathPracticePresenter$present$2$1.invokeSuspend(...)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(...)
	at kotlinx.coroutines.DispatchedTask.run(...)
	at androidx.compose.ui.platform.AndroidUiDispatcher.performTrampolineDispatch(...)
```

**Root Cause:**

The `generateProblemsWithUniqueStrings()` function uses `actualGradeLevel!!` (non-null assertion) to access the user's grade level when regenerating problems. However, `actualGradeLevel` is initialized as `null` and only assigned a value **after** this function is called.

The problematic code sequence was:
```kotlin
// Before fix
val problems = generateProblemsWithUniqueStrings(generatedProblems, count)
                              // Function uses actualGradeLevel!!
actualGradeLevel = grade  // <- This assignment happens AFTER the call
```

This caused a `NullPointerException` when the function tried to access `actualGradeLevel!!` inside the retry loop (line 195).

## Solution

The fix ensures `actualGradeLevel` is assigned **before** calling `generateProblemsWithUniqueStrings()` in all three code paths:

1. **Custom Challenge Fallback Path** (lines 245-261)
   - Set `actualGradeLevel = grade` immediately before validating problems
   
2. **Adaptive Mode Path** (lines 276-282)
   - Set `actualGradeLevel = result.actualGradeLevel` immediately after generating adaptive problems
   
3. **Standard Generation Path** (lines 309-315)
   - Set `actualGradeLevel = grade` immediately before validating problems

### Changed Code Pattern

**Before:**
```kotlin
val problems = generateProblemsWithUniqueStrings(generatedProblems, count)
actualGradeLevel = grade
```

**After:**
```kotlin
actualGradeLevel = grade
val problems = generateProblemsWithUniqueStrings(generatedProblems, count)
```

## Testing

✅ Build verified successful with `./gradlew assembleDebug`
✅ Kotlin code formatted with `./gradlew formatKotlin`
✅ No compilation errors
✅ Fix addresses all three code paths that call the function

## Impact

This fix resolves the crash that prevents users from starting any practice session in the app. The crash was introduced by the duplicate problem prevention feature added in a recent change.

## Files Modified

- `app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt`
  - Reordered initialization of `actualGradeLevel` to occur before `generateProblemsWithUniqueStrings()` calls
  - Applied to 3 distinct code paths (custom challenges, adaptive mode, standard generation)