### PR TITLE
chore: Release 1.14.1 hotfix for Math Practice crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2025-12-25
+
+### Fixed
+- **Math Practice Null Pointer Exception** - Fixed critical crash in `MathPracticePresenter.generateProblemsWithUniqueStrings()`
+  - Root cause: `actualGradeLevel` variable was used with non-null assertion (`!!`) before being initialized
+  - Solution: Reordered code to assign `actualGradeLevel` BEFORE calling `generateProblemsWithUniqueStrings()` in all three code paths
+  - Applied to: custom challenge fallback, adaptive mode, and standard problem generation
+  - Fixes crash that prevented users from starting any practice session
+
 ## [1.14.0] - 2025-12-25
 
 ### Added
@@ -1767,7 +1776,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied proper system bars insets for edge-to-edge display on onboarding screen
 - Fixed onboarding navigation to properly navigate to MathPracticeScreen after completion
 
-[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.14.0...HEAD
+[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.14.1...HEAD
+[1.14.1]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.14.0...1.14.1
 [1.14.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.13.0...1.14.0
 [1.13.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.12.0...1.13.0
 [1.12.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.11.0...1.12.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "dev.hossain.mathtutor"
         minSdk = 28
         targetSdk = 36
-        versionCode = 15
-        versionName = "1.14.0"
+        versionCode = 16
+        versionName = "1.14.1"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.14.1 - Hotfix for Math Practice Crash

This hotfix release addresses a critical `NullPointerException` crash that prevented users from starting any practice session in the app.

### What's Fixed

**Math Practice Null Pointer Exception** 
- Fixed crash in `MathPracticePresenter.generateProblemsWithUniqueStrings()`
- Root cause: `actualGradeLevel` was used with non-null assertion (`!!`) before being initialized
- Solution: Reordered initialization to assign `actualGradeLevel` BEFORE calling the function
- Applied fix to all three code paths:
  - Custom challenge fallback
  - Adaptive mode
  - Standard problem generation

### Version Updates

- versionCode: 15 → 16
- versionName: 1.14.0 → 1.14.1

### Testing

✅ Build verified successful
✅ Code formatted with formatKotlin
✅ Fix resolves the crashing issue that was blocking the entire practice feature

### Release Notes

This is a critical hotfix release addressing a regression introduced in 1.14.0. Users experiencing crashes when starting a practice session should update to this version.

---

Refer to #326 for the original fix details.