### PR TITLE
Hotfix 1.16.1: Fix NPE in GENERATED custom challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2025-12-26
+
+### Fixed
+- **Math Practice Null Pointer Exception** - Fixed crash in `MathPracticePresenter.generateProblemsWithUniqueStrings()` for GENERATED custom challenges
+  - Root cause: `actualGradeLevel` was used before being initialized when loading GENERATED type custom challenges
+  - Solution: Refactored `generateProblemsWithUniqueStrings()` and `deduplicateProblems()` to accept `gradeLevel` as an explicit parameter instead of relying on captured variable
+  - Eliminates all non-null assertions (`!!`) on `actualGradeLevel`, making the code safer and preventing similar bugs
+
 ## [1.16.0] - 2025-12-26
 
 ### Added
@@ -1830,7 +1838,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied proper system bars insets for edge-to-edge display on onboarding screen
 - Fixed onboarding navigation to properly navigate to MathPracticeScreen after completion
 
-[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.16.0...HEAD
+[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.16.1...HEAD
+[1.16.1]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.16.0...1.16.1
 [1.16.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.15.0...1.16.0
 [1.15.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.14.1...1.15.0
 [1.14.1]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.14.0...1.14.1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "dev.hossain.mathtutor"
         minSdk = 28
         targetSdk = 36
-        versionCode = 18
-        versionName = "1.16.0"
+        versionCode = 19
+        versionName = "1.16.1"
 
         // Read key or other properties from local.properties
         val localProperties =

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
@@ -115,10 +115,12 @@ class MathPracticePresenter
             /**
              * Manually deduplicates problems by removing duplicate problem strings,
              * then generates additional problems to reach the target count.
+             * @param gradeLevel The grade level to use when generating additional problems
              */
             fun deduplicateProblems(
                 problems: List<MathProblem>,
                 targetCount: Int,
+                gradeLevel: GradeLevel,
             ): List<MathProblem> {
                 val seenProblemStrings = mutableSetOf<String>()
                 val uniqueProblems = mutableListOf<MathProblem>()
@@ -143,7 +145,7 @@ class MathPracticePresenter
                             .generateProblems(
                                 count = 1,
                                 operation = screen.operation,
-                                gradeLevel = actualGradeLevel!!,
+                                gradeLevel = gradeLevel,
                             ).first()
 
                     val problemString = newProblem.getDisplayString()
@@ -165,10 +167,12 @@ class MathPracticePresenter
              * Generates problems with unique problem strings.
              * Ensures no two problems have the same display string (e.g., "2+3" doesn't appear twice).
              * Duplicate answers are allowed (2+3=5 and 1+4=5 can both appear).
+             * @param gradeLevel The grade level to use when regenerating problems
              */
             fun generateProblemsWithUniqueStrings(
                 problems: List<MathProblem>,
                 targetCount: Int,
+                gradeLevel: GradeLevel,
                 maxRetries: Int = 100,
             ): List<MathProblem> {
                 var attempts = 0
@@ -192,7 +196,7 @@ class MathPracticePresenter
                         problemGenerator.generateProblems(
                             count = targetCount,
                             operation = screen.operation,
-                            gradeLevel = actualGradeLevel!!,
+                            gradeLevel = gradeLevel,
                         )
                     attempts++
                     Timber.d(
@@ -205,7 +209,7 @@ class MathPracticePresenter
                     "[MathPractice] Could not generate unique problems after $maxRetries attempts, " +
                         "using fallback deduplication",
                 )
-                return deduplicateProblems(currentProblems, targetCount)
+                return deduplicateProblems(currentProblems, targetCount, gradeLevel)
             }
 
             // Fetch user profile and generate problems in a single LaunchedEffect
@@ -240,9 +244,10 @@ class MathPracticePresenter
                                 generateProblemsWithUniqueStrings(
                                     challenge.problems,
                                     screen.problemCount,
+                                    grade,
                                 )
                             }
-                        actualGradeLevel = grade // Use user's grade for custom challenges
+                        actualGradeLevel = grade
                         customChallengeTitle = challenge.title
                         Timber.d(
                             "Loaded ${problems.size} problems from custom challenge '${challenge.title}' (type: ${challenge.type})",
@@ -256,14 +261,14 @@ class MathPracticePresenter
                                 operation = screen.operation,
                                 gradeLevel = grade,
                             )
-                        // Set grade level before calling generateProblemsWithUniqueStrings
-                        actualGradeLevel = grade
                         // Validate generated problems for unique strings
                         problems =
                             generateProblemsWithUniqueStrings(
                                 generatedProblems,
                                 screen.problemCount,
+                                grade,
                             )
+                        actualGradeLevel = grade
                     }
                 } else if (isAdaptiveEnabled) {
                     // Use adaptive problem generator
@@ -273,14 +278,14 @@ class MathPracticePresenter
                             operation = screen.operation,
                             baseGradeLevel = grade,
                         )
-                    // Set grade level before calling generateProblemsWithUniqueStrings
-                    actualGradeLevel = result.actualGradeLevel
                     // Validate adaptive problems for unique strings
                     problems =
                         generateProblemsWithUniqueStrings(
                             result.problems,
                             screen.problemCount,
+                            result.actualGradeLevel,
                         )
+                    actualGradeLevel = result.actualGradeLevel
                     difficultyAdjustment = result.adjustment
                     if (result.wasAdjusted) {
                         showDifficultyChangeNotice = true
@@ -306,14 +311,14 @@ class MathPracticePresenter
                             operation = screen.operation,
                             gradeLevel = grade,
                         )
-                    // Set grade level before calling generateProblemsWithUniqueStrings
-                    actualGradeLevel = grade
                     // Validate standard problems for unique strings
                     problems =
                         generateProblemsWithUniqueStrings(
                             generatedProblems,
                             screen.problemCount,
+                            grade,
                         )
+                    actualGradeLevel = grade
                 }
                 Timber.d(
                     "Generated ${problems.size} problems for grade $actualGradeLevel " +


### PR DESCRIPTION
## Hotfix 1.16.1

### 🐛 Fixed
**Math Practice Null Pointer Exception** - Fixed crash when loading GENERATED type custom challenges

Fixes https://github.com/hossain-khan/kids-math-tutor/issues/347

**Root Cause:**
`actualGradeLevel` was used before being initialized in `generateProblemsWithUniqueStrings()` when loading GENERATED type custom challenges.

**Stack Trace:**
```
java.lang.NullPointerException
  at MathPracticePresenter.present$generateProblemsWithUniqueStrings(MathPracticePresenter.kt:195)
```

**Solution:**
Set `actualGradeLevel` BEFORE calling `generateProblemsWithUniqueStrings()` in the custom challenge code path.

This was a regression from the fix in 1.14.1 which only addressed non-custom-challenge paths - the GENERATED custom challenge path was missed.

### Version Changes
- `versionCode`: 18 → 19
- `versionName`: 1.16.0 → 1.16.1