### PR TITLE
fix: Navigate to challenges list after deeplink import instead of clo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All template configs now include the required `"type"` field (`"generated"` or `"explicit"`)
   - Ensures deeplinks work without requiring auto-detection fallback
   - Matches official JSON schema at https://math-worksheet.gohk.xyz/challenge-schema.json
+- **Deeplink Import Navigation** - Fixed app closing after importing challenge via deeplink
+  - App now navigates to challenges list after successful deeplink import instead of closing
+  - Users can immediately see their imported challenge from webapp "Open in App" button
+  - Normal import flow (from within app) remains unchanged with proper back navigation
 
 ### Improved
 - **Enhanced Import Challenge UI** - Applied Material 3 design improvements

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
@@ -17,6 +17,7 @@ import dev.hossain.mathtutor.domain.parser.ChallengeJsonParser
 import dev.hossain.mathtutor.domain.parser.ValidationException
 import dev.hossain.mathtutor.domain.repository.CustomChallengeRepository
 import dev.hossain.mathtutor.domain.service.CustomChallengeService
+import dev.hossain.mathtutor.ui.parentchallenges.ParentChallengesScreen
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -185,13 +186,22 @@ class ImportChallengePresenter
                                                 // Persist to repository
                                                 challengeRepository.saveChallenge(challenge)
                                                 Timber.d("ImportChallenge: Challenge saved: ${challenge.title}")
-                                                // Navigate back with result for parent to show success message
-                                                navigator.pop(
-                                                    result =
-                                                        ImportChallengeScreen.ImportResult(
-                                                            challengeTitle = challenge.title,
-                                                        ),
-                                                )
+
+                                                // If we came from a deeplink (no back stack), navigate to ParentChallengesScreen
+                                                // Otherwise, pop back to the previous screen
+                                                if (screen.prefilledJson != null) {
+                                                    // Deeplink scenario - go to challenges list
+                                                    Timber.d("ImportChallenge: Deeplink import - navigating to ParentChallengesScreen")
+                                                    navigator.resetRoot(ParentChallengesScreen)
+                                                } else {
+                                                    // Normal flow - pop back with result for parent to show success message
+                                                    navigator.pop(
+                                                        result =
+                                                            ImportChallengeScreen.ImportResult(
+                                                                challengeTitle = challenge.title,
+                                                            ),
+                                                    )
+                                                }
                                             }.onFailure { error ->
                                                 Timber.e(error, "Failed to create challenge")
                                                 validationState =


### PR DESCRIPTION
…sing app

When importing a challenge via deeplink (e.g., 'Open in App' button from webapp), the app would close after successful import because there was no back stack to pop to.

Changes:
- Check if ImportChallengeScreen was opened with prefilledJson (deeplink scenario)
- If yes: use navigator.resetRoot(ParentChallengesScreen) to go to challenges list
- If no: use navigator.pop() as before to return to previous screen

This ensures users can see their imported challenges immediately after using deeplinks, providing better UX for webapp template imports.

Fixes: App closing after deeplink import