### PR TITLE
chore: Prepare release 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] - 2025-12-27
+
 ### Added
 - **Duplicate Challenge Detection** - Import Challenge screen now checks for duplicate challenges before saving
   - Validates if an imported challenge already exists based on challenge type and problem content
   - Displays clear error message with the existing challenge's title to help parents identify duplicates
   - Prevents accidental imports of the same challenge multiple times
+- **Schema Compliance Tests** - Added comprehensive tests to validate 100% compliance with webapp JSON schema
+  - Tests both official schema examples (generated and explicit challenges)
+  - Validates all field constraints, enums, and boundary values
+  - Ensures seamless integration between webapp and Android app
 
 ### Changed
 - **Improved Import Challenge Validation Messages** - Enhanced parent experience when importing challenges
@@ -43,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - More descriptive success/error icons and messaging
   - Loading state now shows "Saving..." text for better feedback
   - Preview section header clearly labeled as "Challenge Preview"
+- **Developer Experience** - Added Compose previews for Import Challenge UI
+  - 7 preview composables covering all major UI states (empty, with input, validation, errors, loading, share detection)
+  - Enables faster UI development and validation without running the app
 
 ## [1.16.1] - 2025-12-26
 
@@ -1875,7 +1884,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied proper system bars insets for edge-to-edge display on onboarding screen
 - Fixed onboarding navigation to properly navigate to MathPracticeScreen after completion
 
-[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.16.1...HEAD
+[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.17.0...HEAD
+[1.17.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.16.1...1.17.0
 [1.16.1]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.16.0...1.16.1
 [1.16.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.15.0...1.16.0
 [1.15.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.14.1...1.15.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "dev.hossain.mathtutor"
         minSdk = 28
         targetSdk = 36
-        versionCode = 19
-        versionName = "1.16.1"
+        versionCode = 20
+        versionName = "1.17.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
Updated version:
- versionCode: 19 → 20
- versionName: 1.16.1 → 1.17.0

Changelog updates:
- Moved all [Unreleased] items to [1.17.0] - 2025-12-27
- Updated version comparison links
- Added new empty [Unreleased] section

Release highlights:
- Enhanced import challenge experience with duplicate detection
- Fixed deeplink navigation and JSON schema compliance
- Improved UI with Material 3 design and Compose previews
- 100% webapp JSON schema compliance verified with tests