### PR TITLE
chore: Add npx prefix to wrangler commands and improve installation docs

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -39,6 +39,23 @@ Web-based worksheet creator for the Kids Math Pup Tutor Android app. Create cust
 pnpm install
 ```
 
+### Prerequisites for Development
+
+Before running the development server, ensure you have the Cloudflare Workers CLI installed:
+
+```bash
+# Install wrangler (Cloudflare Workers CLI) globally
+npm install -g wrangler
+
+# Or use npx to run wrangler commands without global installation
+# All wrangler commands in this project are run with: npx wrangler <command>
+```
+
+You can verify wrangler is installed:
+```bash
+wrangler --version
+```
+
 ### Development
 
 #### Local Development Server (Frontend + Backend)
@@ -47,7 +64,7 @@ To run the full development environment with both the frontend and API:
 
 ```bash
 # Terminal 1: Start the Wrangler dev server (API on port 8787)
-wrangler dev --env development
+npx wrangler dev --env development
 
 # Terminal 2: Start the Vite dev server (Frontend on port 5173)
 pnpm dev
@@ -125,7 +142,7 @@ The deployment uses environment-specific configurations in `wrangler.json`:
 - **Development**: Uses local password from `wrangler.json` for local testing
 
 **⚠️ Important Configuration Detail**:
-When using `wrangler deploy --env production`, Cloudflare automatically creates a new worker with a `-production` suffix if the `name` field is not explicitly set in the environment config. This can create a separate, unreachable worker instance without routes.
+When using `npx wrangler deploy --env production`, Cloudflare automatically creates a new worker with a `-production` suffix if the `name` field is not explicitly set in the environment config. This can create a separate, unreachable worker instance without routes.
 
 To prevent this, the `wrangler.json` must include `"name": "pup-tutor-worksheet-generator"` in the production environment section:
 
@@ -144,7 +161,7 @@ Without this, the production deployment creates `pup-tutor-worksheet-generator-p
 
 For production, set the admin password as a Cloudflare secret:
 ```bash
-wrangler secret put ADMIN_PASSWORD --env production
+npx wrangler secret put ADMIN_PASSWORD --env production
 ```
 
 ## Project Structure
@@ -176,7 +193,7 @@ The webapp is deployed as a static SPA to Cloudflare Workers.
 pnpm build
 
 # Deploy to Cloudflare Workers (production environment)
-wrangler deploy --env production
+npx wrangler deploy --env production
 ```
 
 ### First-Time Setup
@@ -188,11 +205,11 @@ If you haven't deployed before:
 npx wrangler login
 
 # 2. Set the admin password as a Cloudflare secret
-wrangler secret put ADMIN_PASSWORD
+npx wrangler secret put ADMIN_PASSWORD --env production
 # Enter your secure admin password when prompted
 
 # 3. Build and deploy
-pnpm build && wrangler deploy --env production
+pnpm build && npx wrangler deploy --env production
 ```
 
 The configuration is in `wrangler.json`:

--- a/webapp/docs/ADMIN_IMPLEMENTATION.md
+++ b/webapp/docs/ADMIN_IMPLEMENTATION.md
@@ -130,13 +130,13 @@ All endpoints validate Bearer token before allowing access.
 ### 2. Production
 ```bash
 # Set password as Cloudflare secret (REQUIRED for production)
-wrangler secret put ADMIN_PASSWORD --env production
+npx wrangler secret put ADMIN_PASSWORD --env production
 
 # Verify secret is set
-wrangler secret list --env production
+npx wrangler secret list --env production
 
 # Deploy
-wrangler deploy --env production
+npx wrangler deploy --env production
 
 # Access:
 # https://math-worksheet.gohk.xyz/manage-worksheets

--- a/webapp/docs/ADMIN_QUICK_START.md
+++ b/webapp/docs/ADMIN_QUICK_START.md
@@ -20,11 +20,11 @@ https://math-worksheet.gohk.xyz/manage-worksheets
 
 **Production (Cloudflare Secrets - REQUIRED):**
 ```bash
-wrangler secret put ADMIN_PASSWORD --env production
+npx wrangler secret put ADMIN_PASSWORD --env production
 # Enter your secure password when prompted
 
 # Verify it was set:
-wrangler secret list --env production
+npx wrangler secret list --env production
 ```
 
 ⚠️ **Important:** Production passwords MUST use Cloudflare Secrets, not `wrangler.json`

--- a/webapp/docs/ADMIN_SETUP.md
+++ b/webapp/docs/ADMIN_SETUP.md
@@ -47,7 +47,7 @@ Edit `webapp/wrangler.json` and set the admin password for development:
 Then run:
 ```bash
 cd webapp
-pnpm dev
+npx wrangler dev --env development
 # Visit http://localhost:5173/manage-worksheets
 ```
 
@@ -59,14 +59,14 @@ For production, **you MUST use Cloudflare Secrets** to securely store the passwo
 
 ```bash
 # Set the admin password as a secret on Cloudflare
-wrangler secret put ADMIN_PASSWORD --env production
+npx wrangler secret put ADMIN_PASSWORD --env production
 
 # When prompted, enter your secure production password
 ```
 
 You can verify the secret was set:
 ```bash
-wrangler secret list --env production
+npx wrangler secret list --env production
 ```
 
 **Important Security Notes:**
@@ -77,7 +77,7 @@ wrangler secret list --env production
 
 Deploy with:
 ```bash
-wrangler deploy --env production
+npx wrangler deploy --env production
 ```
 
 **⚠️ Critical Configuration**: When deploying to production, your `wrangler.json` production environment MUST include the worker name to prevent creating a separate unrouted worker:
@@ -204,7 +204,7 @@ clearAdminAuthToken();
 
 ### Can't Remember Password
 - Check `wrangler.json` in development
-- For production, use `wrangler secret list` to verify it's set
+- For production, use `npx wrangler secret list` to verify it's set
 - Contact your infrastructure team if needed
 
 ## Future Enhancements
@@ -231,7 +231,7 @@ Possible improvements:
 
 3. **Use Secrets in Production**
    - Don't hardcode passwords in version control
-   - Use `wrangler secret put` for production
+   - Use `npx wrangler secret put` for production
 
 4. **Monitor Access**
    - Keep logs of who accessed the portal

--- a/webapp/docs/KV_SETUP.md
+++ b/webapp/docs/KV_SETUP.md
@@ -44,7 +44,7 @@ In `/webapp/wrangler.json`, the KV namespace is configured:
 
 ### 4. KV Usage by Environment
 
-- **Local Development** (`wrangler dev` / `pnpm run worker:dev`):
+- **Local Development** (`npx wrangler dev` / `pnpm run worker:dev`):
   - Runs on `localhost:8787`
   - Uses **preview KV** namespace (`preview_id`)
   - Data is separate from production
@@ -145,7 +145,7 @@ ratelimit:192.168.1.1:2025-12-26 → "5"
 ### "KV Namespace not found" Error
 - Verify namespace IDs in `wrangler.json` are correct
 - Check that namespaces exist in Cloudflare Dashboard
-- For local dev, use `wrangler dev` (uses preview namespace)
+- For local dev, use `npx wrangler dev` (uses preview namespace)
 
 ### Data Not Persisting Across Requests
 - Local preview KV is ephemeral (resets on each dev server restart)

--- a/webapp/docs/WORKSHEET_CREATOR_WEBSITE.md
+++ b/webapp/docs/WORKSHEET_CREATOR_WEBSITE.md
@@ -1274,11 +1274,11 @@ VITE_ANALYTICS_ENABLED=false
 npm install -g wrangler
 
 # Login to Cloudflare
-wrangler login
+npx wrangler login
 
 # Start local worker
 cd workers
-wrangler dev
+npx wrangler dev
 
 # Worker runs at http://localhost:8787
 ```
@@ -1292,11 +1292,11 @@ pnpm build
 pnpm preview
 
 # Deploy to Cloudflare Pages
-wrangler pages deploy dist
+npx wrangler pages deploy dist
 
 # Deploy Workers API
 cd workers
-wrangler deploy
+npx wrangler deploy
 ```
 
 ### wrangler.toml Configuration


### PR DESCRIPTION
## Overview
Adds `npx` prefix to all wrangler commands and improves installation documentation for better developer experience.

## Changes Made

### Documentation Updates
- **README.md**:
  - Added new "Prerequisites for Development" section
  - Explains how to install wrangler CLI globally or use npx
  - Includes verification command: `wrangler --version`
  - Updated all wrangler commands with `npx` prefix

### Command Updates (with npx prefix)
- Updated commands in all documentation files:
  - `npx wrangler dev --env development`
  - `npx wrangler deploy --env production`
  - `npx wrangler secret put/list`
  - `npx wrangler login`

### Files Updated
- ✅ README.md - Added prerequisites and npx prefix to all commands
- ✅ ADMIN_SETUP.md - Added npx prefix to secret and deploy commands
- ✅ ADMIN_QUICK_START.md - Updated secret commands with npx
- ✅ ADMIN_IMPLEMENTATION.md - Updated all production setup commands
- ✅ WORKSHEET_CREATOR_WEBSITE.md - Updated worker development commands
- ✅ KV_SETUP.md - Updated local dev and deployment commands

## Benefits

✅ **Better Developer Experience** - npx allows running wrangler without global installation  
✅ **Consistent Documentation** - All commands follow same pattern  
✅ **Clearer Setup** - Prerequisites section explains installation options  
✅ **Flexibility** - Developers can choose global install or per-project npx usage  

## Installation Notes

Developers can now either:
1. Install wrangler globally: `npm install -g wrangler`
2. Use npx for per-project execution (no global install needed)

Both approaches are documented in the README.