### PR TITLE
fix: Improve Llama Guard 3 prompt for better profanity detection

### DIFF
--- a/webapp/src/lib/server/aiSafety.ts
+++ b/webapp/src/lib/server/aiSafety.ts
@@ -56,25 +56,22 @@ export async function checkContentSafetyWithAI(
   }
 
   try {
-    const prompt = `You are a content safety classifier for children's educational materials (K-2 grade level, ages 5-8).
+    const prompt = `You are a strict content safety classifier for children's educational materials (K-2 grade level, ages 5-8).
 
-Analyze the following worksheet content for age-appropriateness and safety:
+STRICT RULES:
+1. ANY profanity, slurs, or curse words = UNSAFE (even mild ones like "damn", "hell", "ass", "sucks", etc.)
+2. ANY crude or sexual language = UNSAFE  
+3. ANY violence or weapons = UNSAFE
+4. ANY drug/alcohol references = UNSAFE
+5. Adult themes, romance, dating = UNSAFE
+6. Scary or disturbing content = UNSAFE
 
+Analyze this worksheet content:
 TITLE: "${content.title}"
 ${content.subtitle ? `SUBTITLE: "${content.subtitle}"` : ""}
 ${content.description ? `DESCRIPTION: "${content.description}"` : ""}
 
-Classify as SAFE or UNSAFE for K-2 children (ages 5-8).
-
-Consider:
-- Violence, weapons, dangerous activities
-- Inappropriate language or slurs
-- Adult content, dating, romance
-- Scary or disturbing content
-- Drug references
-- Profanity or crude humor
-
-If UNSAFE, list the specific concerns.
+Classification for K-2 children (ages 5-8):
 
 Respond ONLY with valid JSON (no markdown, no code blocks):
 {
@@ -95,6 +92,9 @@ Respond ONLY with valid JSON (no markdown, no code blocks):
         },
       ],
     });
+
+    // Log raw response for debugging safety issues
+    console.log('[AI] Raw response:', JSON.stringify(response).substring(0, 500));
 
     // Parse response - handle various formats
     let result;

--- a/webapp/workers/api.ts
+++ b/webapp/workers/api.ts
@@ -159,6 +159,15 @@ app.post('/api/v1/worksheets/share', async (c) => {
       description: worksheetData.description,
     });
 
+    console.log('[SHARE] Safety check result:', {
+      safe: safetyResult.safe,
+      classification: safetyResult.classification,
+      usingAI: safetyResult.usingAI,
+      fallback: safetyResult.fallback,
+      confidence: safetyResult.confidence,
+      title: worksheetData.title,
+    });
+
     if (!safetyResult.safe) {
       return c.json(
         {


### PR DESCRIPTION
## Summary

Improved the Llama Guard 3 AI prompt to be more explicit about profanity detection for K-2 children's educational materials. The original prompt was too vague and resulted in Llama Guard 3 not consistently classifying mild profanity as unsafe.

## Problem

When testing the worksheet sharing feature, worksheets containing profanity (like "suck ass") were being accepted as safe, even though they should be blocked for young children (K-2).

## Solution

Updated the AI safety check prompt to:
- Add a **STRICT RULES section** with explicit examples
- List common profanity explicitly: "damn", "hell", "ass", "sucks", etc.
- Clarify that **ANY profanity = UNSAFE** for K-2 children
- Provide clear categories for other unsafe content (sexual, violence, drugs)

## Verification

✅ **Blocks inappropriate content:**
```
Title: "Simple Addition - you suck ass"
Response: "Worksheet contains inappropriate content for children"
Method: "AI-based safety check"
```

✅ **Accepts clean content:**
```
Title: "Simple Addition Practice"
Response: 201 Created + sharing link
```

✅ **Using proper AI classification:**
- `usingAI: true` (not fallback)
- `fallback: false`
- `confidence: 0.95`

## Changes

**webapp/src/lib/server/aiSafety.ts**
- Improved prompt structure with STRICT RULES
- Added explicit profanity examples
- Clearer instructions for unsafe categories
- Better formatted for Llama Guard 3 understanding

## Deployment

✅ **Version 6598cd9c-873a-46f4-9812-5af29ba8587c** deployed and tested successfully
- Both bindings confirmed: `env.KV` ✅ and `env.AI` ✅
- Profanity detection working correctly

## Next Steps

After merging:
1. All future worksheet shares will have proper profanity filtering
2. Both the share workflow and admin bulk checks benefit from this improvement
3. Safe, educational content is still freely shared