### PR TITLE
feat: Distribute seeded sessions across 5 days with 2 sessions per day

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/devtools/SessionSeeder.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/devtools/SessionSeeder.kt
@@ -13,6 +13,7 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import kotlin.random.Random
 
 /**
@@ -48,8 +49,16 @@ class SessionSeederImpl
                 var seeded = 0
                 val rnd = Random(System.currentTimeMillis())
 
-                repeat(count.coerceAtLeast(0)) {
+                // Distribute sessions across 5 days: 2 per day
+                // Day 0 (today), Day 1 (yesterday), Day 2 (2 days ago), etc.
+                val daysToDistribute = 5
+                val sessionsPerDay = 2
+
+                repeat(count.coerceAtLeast(0)) { index ->
                     try {
+                        val dayOffset = (index / sessionsPerDay) % daysToDistribute
+                        val sessionTimestamp = Instant.now().minus(dayOffset.toLong(), ChronoUnit.DAYS)
+
                         val op =
                             if (operation == MathOperation.MIXED) {
                                 // pick a random non-mixed operation
@@ -95,7 +104,7 @@ class SessionSeederImpl
                                 answers = answers,
                                 operation = if (operation == MathOperation.MIXED) null else operation,
                                 durationSeconds = durationSec,
-                                completedAt = Instant.now(),
+                                completedAt = sessionTimestamp,
                             )
 
                         sessionRepository.saveSession(


### PR DESCRIPTION
## Description
Improved the "Seed Sample Sessions" feature in the Developer Portal to distribute sessions across multiple days instead of all on the same day.

## Changes
- Modified `SessionSeeder.seedSampleSessions()` to spread sessions across 5 days
- Sessions are distributed with 2 sessions per day:
  - Day 0 (sessions 0-1): Today
  - Day 1 (sessions 2-3): Yesterday  
  - Day 2 (sessions 4-5): 2 days ago
  - Day 3 (sessions 6-7): 3 days ago
  - Day 4 (sessions 8-9): 4 days ago
- Added `ChronoUnit` import for date arithmetic
- Maintains all other seeding logic (accuracy, problem generation, etc.)

## Benefits
- ✅ More realistic test data for dashboard and analytics
- ✅ Better testing of date-based filtering and statistics
- ✅ Sessions now have meaningful temporal distribution
- ✅ 2 sessions per day provides good sample coverage

## Testing
- ✅ All pre-commit checks passing (formatting, linting, unit tests)
- ✅ SessionSeeder behavior preserved, only timing logic changed
- ✅ No breaking changes to existing functionality

## Type of Change
- [x] New feature (improved seeding behavior)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Related Issues
Improves developer testing experience with more realistic sample data distribution