### PR TITLE
feat: Distribute seeded challenge practice sessions across multiple days

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/devtools/SessionSeeder.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/devtools/SessionSeeder.kt
@@ -13,6 +13,7 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import kotlin.random.Random
 
 /**
@@ -48,8 +49,16 @@ class SessionSeederImpl
                 var seeded = 0
                 val rnd = Random(System.currentTimeMillis())
 
-                repeat(count.coerceAtLeast(0)) {
+                // Distribute sessions across 5 days: 2 per day
+                // Day 0 (today), Day 1 (yesterday), Day 2 (2 days ago), etc.
+                val daysToDistribute = 5
+                val sessionsPerDay = 2
+
+                repeat(count.coerceAtLeast(0)) { index ->
                     try {
+                        val dayOffset = (index / sessionsPerDay) % daysToDistribute
+                        val sessionTimestamp = Instant.now().minus(dayOffset.toLong(), ChronoUnit.DAYS)
+
                         val op =
                             if (operation == MathOperation.MIXED) {
                                 // pick a random non-mixed operation
@@ -95,7 +104,7 @@ class SessionSeederImpl
                                 answers = answers,
                                 operation = if (operation == MathOperation.MIXED) null else operation,
                                 durationSeconds = durationSec,
-                                completedAt = Instant.now(),
+                                completedAt = sessionTimestamp,
                             )
 
                         sessionRepository.saveSession(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenter.kt
@@ -765,46 +765,50 @@ class DeveloperPortalPresenter
                 }
             }
 
-            // Add practice sessions for 2 of the challenges
-            // Quick Addition: 3 sessions at 90% accuracy
+            // Add practice sessions for 2 of the challenges, distributed across days
+            // Quick Addition: 3 sessions at 90% accuracy, spread across 3 days
             val quickAdditionChallenge = createdChallengeIds.find { it.first == "Quick Addition" }
             if (quickAdditionChallenge != null) {
                 repeat(3) { sessionIndex ->
-                    val now = Instant.now()
+                    val dayOffset = sessionIndex.toLong() // 0, 1, 2 days ago
+                    val baseTime = Instant.now().minus(dayOffset, java.time.temporal.ChronoUnit.DAYS)
                     val session =
                         ChallengePracticeSession(
-                            startTime = now.minusSeconds((3 - sessionIndex).toLong() * 300), // Stagger sessions
-                            endTime = now.minusSeconds((3 - sessionIndex).toLong() * 300).plusSeconds(120),
+                            startTime = baseTime.minusSeconds(120),
+                            endTime = baseTime.minusSeconds(120).plusSeconds(120),
                             problemsAttempted = 10,
                             correctAnswers = 9, // 90% accuracy
                             totalTimeMs = 120000,
                         )
                     try {
                         customChallengeService.recordPracticeSession(quickAdditionChallenge.second, session)
-                        Timber.d("[DevPortal] Recorded session $sessionIndex for Quick Addition (90% accuracy)")
+                        Timber.d("[DevPortal] Recorded session $sessionIndex for Quick Addition (90% accuracy, ${dayOffset}d ago)")
                     } catch (e: Exception) {
                         Timber.e(e, "[DevPortal] Failed to record session for Quick Addition")
                     }
                 }
             }
 
-            // Quick Subtraction: 1 session at 45% accuracy
+            // Quick Subtraction: 2 sessions at 50% accuracy, spread across 2 days
             val quickSubtractionChallenge = createdChallengeIds.find { it.first == "Quick Subtraction" }
             if (quickSubtractionChallenge != null) {
-                val now = Instant.now()
-                val session =
-                    ChallengePracticeSession(
-                        startTime = now.minusSeconds(600),
-                        endTime = now.minusSeconds(600).plusSeconds(90),
-                        problemsAttempted = 10,
-                        correctAnswers = 5, // 50% accuracy (close to 45%)
-                        totalTimeMs = 90000,
-                    )
-                try {
-                    customChallengeService.recordPracticeSession(quickSubtractionChallenge.second, session)
-                    Timber.d("[DevPortal] Recorded session for Quick Subtraction (50 percent accuracy)")
-                } catch (e: Exception) {
-                    Timber.e(e, "[DevPortal] Failed to record session for Quick Subtraction")
+                repeat(2) { sessionIndex ->
+                    val dayOffset = (sessionIndex + 3).toLong() // 3, 4 days ago
+                    val baseTime = Instant.now().minus(dayOffset, java.time.temporal.ChronoUnit.DAYS)
+                    val session =
+                        ChallengePracticeSession(
+                            startTime = baseTime.minusSeconds(90),
+                            endTime = baseTime.minusSeconds(90).plusSeconds(90),
+                            problemsAttempted = 10,
+                            correctAnswers = 5, // 50% accuracy
+                            totalTimeMs = 90000,
+                        )
+                    try {
+                        customChallengeService.recordPracticeSession(quickSubtractionChallenge.second, session)
+                        Timber.d("[DevPortal] Recorded session $sessionIndex for Quick Subtraction (50% accuracy, ${dayOffset}d ago)")
+                    } catch (e: Exception) {
+                        Timber.e(e, "[DevPortal] Failed to record session for Quick Subtraction")
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description
Enhanced the "Import Sample Challenges" feature in the Developer Portal to distribute challenge practice sessions across multiple days for more realistic test data.

## Changes
Modified `importSampleChallenges()` function in `DeveloperPortalPresenter`:
- **Quick Addition**: 3 sessions spread across 3 days (today, yesterday, 2 days ago)
- **Quick Subtraction**: 2 sessions spread across 3 and 4 days ago
- Uses `ChronoUnit.DAYS` to calculate temporal distribution
- All sessions maintain their accuracy levels (90% and 50% respectively)

**Before**: All 5 practice sessions seeded on the same day  
**After**: Sessions distributed across 5 days for realistic data patterns

## Benefits
- ✅ More realistic challenge practice statistics
- ✅ Better testing of challenge history and trends
- ✅ Improved accuracy for analytics and performance dashboards
- ✅ Complements the earlier SessionSeeder improvements

## Testing
- ✅ All pre-commit checks passing (formatting, linting, unit tests)
- ✅ No breaking changes to existing functionality
- ✅ Challenge practice session logic preserved

## Type of Change
- [x] New feature (improved seeding behavior)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Related Issues
Complements PR #403 (distribute sessions) with similar improvements for challenge practice data