### PR TITLE
fix: Use session's completedAt timestamp instead of current time

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/data/mapper/SessionMapper.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/mapper/SessionMapper.kt
@@ -35,7 +35,7 @@ object SessionMapper {
             incorrectAnswers = incorrectAnswers,
             accuracy = accuracy,
             durationSeconds = durationSeconds,
-            timestamp = Instant.now(),
+            timestamp = session.completedAt ?: Instant.now(),
             gradeLevel = gradeLevel,
         )
     }


### PR DESCRIPTION
## Description
Critical bug fix for session timestamp handling in the mapper layer. The session mapper was ignoring the `completedAt` timestamp from the session object and always using `Instant.now()`, causing all seeded sessions to appear on the same day.

## Root Cause
In `SessionMapper.toEntity()`, the line:
```kotlin
timestamp = Instant.now(),  // BUG: Always uses current time!
```

This overwrote the intentional temporal distribution in the SessionSeeder, which carefully calculates timestamps across 5 days with 2 sessions per day.

## Changes
Modified [SessionMapper.kt](app/src/main/java/dev/hossain/mathtutor/data/mapper/SessionMapper.kt):
- Changed `timestamp = Instant.now()` to `timestamp = session.completedAt ?: Instant.now()`
- Now respects the `completedAt` timestamp from the PracticeSession object
- Falls back to `Instant.now()` only if `completedAt` is null (backward compatible)

## Impact
✅ **Fixes**: Session seeding now properly distributes sessions across 5 days as intended  
✅ **Enables**: Dashboard analytics and session statistics testing with realistic temporal data  
✅ **Backward Compatible**: Sessions without explicit `completedAt` still work  
✅ **Complements**: PR #403 and #404 (session distribution improvements)

## Testing
- ✅ All pre-commit checks passing (formatting, linting, unit tests)
- ✅ No breaking changes
- ✅ Mapper continues to work for both explicit and implicit timestamps

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues
Fixes the issue where seeded sessions were all appearing on the same day despite session distribution logic in SessionSeeder