### PR TITLE
feat: Session Resumption Dialog (PR #441)

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/HomePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/HomePresenter.kt
@@ -4,7 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -126,6 +129,20 @@ class HomePresenter
             // Collect active goal if one exists
             val activeGoal by goalRepository.getActiveGoal().collectAsState(initial = null)
 
+            // Track whether session resumption dialog has been shown in current session
+            var hasShownSessionResumptionDialog by remember { mutableStateOf(false) }
+
+            // Show resumption dialog on first appearance if goal is active and hasn't been shown yet
+            val showSessionResumptionDialog = activeGoal != null && !hasShownSessionResumptionDialog
+
+            LaunchedEffect(activeGoal?.goal?.id) {
+                val currentGoal = activeGoal
+                if (currentGoal != null && !hasShownSessionResumptionDialog) {
+                    hasShownSessionResumptionDialog = true
+                    Timber.d("HomeScreen: Showing session resumption dialog for goal: ${currentGoal.goal.title}")
+                }
+            }
+
             // Log state changes in LaunchedEffect to avoid recomposition spam
             LaunchedEffect(userProfile?.name, userProfile?.gradeLevel) {
                 Timber.d(
@@ -157,6 +174,7 @@ class HomePresenter
                 recentBadges = recentBadges,
                 activeGoal = activeGoal,
                 isMusicPlaying = isMusicPlaying,
+                showSessionResumptionDialog = showSessionResumptionDialog,
             ) { event ->
                 when (event) {
                     is HomeScreen.Event.StartPracticeClicked -> {
@@ -210,6 +228,16 @@ class HomePresenter
 
                     is HomeScreen.Event.ViewGoalProgressClicked -> {
                         Timber.d("HomeScreen: Navigating to GoalProgressScreen")
+                        navigator.goTo(GoalProgressScreen)
+                    }
+
+                    is HomeScreen.Event.SessionResumptionDismissed -> {
+                        Timber.d("HomeScreen: Session resumption dialog dismissed")
+                        // Dialog is already dismissed, no further action needed
+                    }
+
+                    is HomeScreen.Event.ContinueGoalClicked -> {
+                        Timber.d("HomeScreen: User continuing with active goal from resumption dialog")
                         navigator.goTo(GoalProgressScreen)
                     }
                 }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeScreen.kt
@@ -42,6 +42,7 @@ data object HomeScreen : Screen {
         val recentBadges: List<Badge>,
         val activeGoal: ActiveGoal? = null,
         val isMusicPlaying: Boolean = false,
+        val showSessionResumptionDialog: Boolean = false,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -83,5 +84,15 @@ data object HomeScreen : Screen {
          * User tapped the active goal banner to view progress.
          */
         data object ViewGoalProgressClicked : Event
+
+        /**
+         * User dismissed the session resumption dialog.
+         */
+        data object SessionResumptionDismissed : Event
+
+        /**
+         * User tapped to continue with active goal from resumption dialog.
+         */
+        data object ContinueGoalClicked : Event
     }
 }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeUi.kt
@@ -325,6 +325,19 @@ fun HomeUi(
             }
         }
     }
+
+    // Show session resumption dialog if user has active goal
+    if (state.showSessionResumptionDialog && state.activeGoal != null) {
+        SessionResumptionDialog(
+            activeGoal = state.activeGoal,
+            onContinueClicked = {
+                state.eventSink(HomeScreen.Event.ContinueGoalClicked)
+            },
+            onDismissClicked = {
+                state.eventSink(HomeScreen.Event.SessionResumptionDismissed)
+            },
+        )
+    }
 }
 
 /**

--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/SessionResumptionDialog.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/SessionResumptionDialog.kt
@@ -1,0 +1,76 @@
+package dev.hossain.mathtutor.ui.home
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import dev.hossain.mathtutor.domain.model.goals.ActiveGoal
+
+/**
+ * Dialog that prompts user to resume their active goal session.
+ *
+ * Shown on HomeScreen when:
+ * - Child has an active goal
+ * - Screen first appears
+ * - Dialog hasn't been shown in current session
+ *
+ * Provides two options:
+ * - "Continue" → Navigate to GoalProgressScreen
+ * - "Continue Later" → Dismiss dialog
+ */
+@Composable
+fun SessionResumptionDialog(
+    activeGoal: ActiveGoal,
+    onContinueClicked: () -> Unit,
+    onDismissClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissClicked,
+        title = {
+            Text(
+                text = "Continue your goal?",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        },
+        text = {
+            Text(
+                text = "You have an active goal: 🎯 ${activeGoal.goal.title}\n\nWould you like to continue working on it?",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = onContinueClicked,
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+            ) {
+                Text("Continue")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismissClicked,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary,
+                    ),
+            ) {
+                Text("Continue Later")
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+        titleContentColor = MaterialTheme.colorScheme.onSurface,
+        modifier = modifier,
+    )
+}


### PR DESCRIPTION
## 🎯 Session Resumption Dialog Implementation

### Overview
Displays a dialog prompting the child to continue working on their active goal when they arrive on the home screen. The dialog shows the goal title and provides two clear action options.

### Changes

#### New Components
- **SessionResumptionDialog.kt** - Composable dialog that:
  - Shows active goal title with 🎯 emoji
  - Displays friendly prompt message
  - "Continue" button → navigate to GoalProgressScreen
  - "Continue Later" button → dismiss dialog
  - Uses Material 3 AlertDialog styling

#### Modified Files

**HomeScreen.kt**
- Added `showSessionResumptionDialog: Boolean` property to State
- Added `SessionResumptionDismissed` event
- Added `ContinueGoalClicked` event

**HomePresenter.kt**
- Added state tracking for session resumption dialog visibility
- Track `hasShownSessionResumptionDialog` to prevent repeated prompts
- Show dialog only on first screen appearance when goal is active
- Handle navigation on button clicks

**HomeUi.kt**
- Conditionally render SessionResumptionDialog when `showSessionResumptionDialog` is true
- Connect dialog callbacks to event sink

### Technical Details

#### Dialog Display Logic
- Dialog shows **only once per session** when HomeScreen first appears
- Only shows if an active goal exists (`activeGoal != null`)
- Uses `remember` with `mutableStateOf` to track session state
- Prevents repeated dialogs even if screen is navigated away and back

#### Navigation Pattern
- "Continue" → `ContinueGoalClicked` → Presenter → `navigator.goTo(GoalProgressScreen)`
- "Continue Later" → `SessionResumptionDismissed` → Presenter (no navigation)
- Both cases prevent dialog from reappearing in current session

### Key Features
- ✅ Non-intrusive: Appears as modal overlay, doesn't interrupt home screen
- ✅ Single-show: Respects session state, won't nag repeatedly
- ✅ Clear CTA: Two obvious action buttons with direct navigation
- ✅ Brand-aware: Uses Material 3 theming with brand colors
- ✅ Smart cast fix: Captured activeGoal locally to avoid delegated property issues

### Quality Checks
- ✅ Formatting (Kotlinter/ktlint)
- ✅ Linting (Klint)
- ✅ Unit Tests
- ✅ Debug Build

### Remaining Phase 4 Work
- MathPracticeScreen Integration (Phase 4.5)
- Unit Tests (Phase 4.6)

### Related Issues
- Completes Phase 4.4 Session Resumption Dialog deliverable
- Part of broader goals feature (PR #438, PR #439, PR #440)