### PR TITLE
fix(goals): Persist created goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Test Stability**: Fixed floating-point precision issue in multiple goal tests by using tolerance-based assertions (`isWithin()`) for progress percentage calculations
+- **Goals (Parent UI)**: Fixed Goal Creator "Save" action not persisting new goals (now calls CreateGoalUseCase and shows errors).
 
 ### Added
 - **Goals Feature - Phase 1: Domain Models & Database Layer**

--- a/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorPresenter.kt
@@ -1,16 +1,14 @@
 package dev.hossain.mathtutor.ui.goals.creator
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
-import dev.hossain.mathtutor.domain.model.MathOperation
-import dev.hossain.mathtutor.domain.model.goals.Goal
 import dev.hossain.mathtutor.domain.model.goals.GoalComponent
 import dev.hossain.mathtutor.domain.usecase.goals.CreateGoalUseCase
 import dev.hossain.mathtutor.ui.goals.creator.GoalCreatorScreen.Event
@@ -20,6 +18,8 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AssistedInject
 class GoalCreatorPresenter(
@@ -38,6 +38,8 @@ class GoalCreatorPresenter(
 
     @Composable
     override fun present(): State {
+        val coroutineScope = rememberCoroutineScope()
+
         var currentStep by remember { mutableStateOf(Step.Title) }
         var goalTitle by remember { mutableStateOf("") }
         var goalDescription by remember { mutableStateOf("") }
@@ -93,19 +95,31 @@ class GoalCreatorPresenter(
                 }
 
                 Event.SaveGoal -> {
-                    isLoading = true
-                    error = null
-                    // Create goal in coroutine context (should be wrapped in proper scope)
-                    val newGoal =
-                        Goal(
-                            title = goalTitle,
-                            description = goalDescription,
-                            components = components,
+                    if (isLoading) return
+
+                    coroutineScope.launch {
+                        isLoading = true
+                        error = null
+
+                        Timber.d(
+                            "GoalCreator: Save goal requested (titleLength=%d, componentCount=%d)",
+                            goalTitle.length,
+                            components.size,
                         )
-                    // In a real implementation, this would be properly handled with coroutines
-                    // For now, we'll just navigate back
-                    isLoading = false
-                    navigator.pop()
+
+                        val result = createGoalUseCase(goalTitle, goalDescription, components)
+                        if (result.isSuccess) {
+                            val goalId = result.getOrNull()?.id
+                            Timber.d("GoalCreator: Goal saved successfully (goalId=%s)", goalId)
+                            navigator.pop()
+                        } else {
+                            val message = result.exceptionOrNull()?.message ?: "Failed to save goal"
+                            Timber.w(result.exceptionOrNull(), "GoalCreator: Save goal failed")
+                            error = message
+                        }
+
+                        isLoading = false
+                    }
                 }
 
                 Event.Cancel -> {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorUi.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,6 +52,12 @@ fun GoalCreatorUi(
     modifier: Modifier = Modifier,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.error) {
+        val message = state.error ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+        state.eventSink(Event.DismissError)
+    }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),


### PR DESCRIPTION
## Problem
When creating a new goal through the Goal Creator UI on `goals-feature-base-branch`, the "Save" button did not persist the goal to the database. The logs showed no indication of a save attempt, and the UI would simply navigate back without saving.

## Root Cause
The `GoalCreatorPresenter.handleEvent()` had a stub implementation for `Event.SaveGoal` that only called `navigator.pop()` without invoking the `CreateGoalUseCase`.

## Solution
- **GoalCreatorPresenter.kt**: Updated `Event.SaveGoal` handler to:
  - Properly launch a coroutine with `rememberCoroutineScope()`
  - Call `createGoalUseCase(title, description, components)` to persist the goal
  - Log success/failure with Timber for debugging
  - Only navigate back on success
  - Surface error messages on failure

- **GoalCreatorUi.kt**: Added error snackbar display:
  - `LaunchedEffect` observes `state.error`
  - Automatically shows error via snackbar when save fails
  - Triggers `DismissError` event to clear the error state

- **CHANGELOG.md**: Documented the fix

## Testing
✅ Unit tests pass (testDebugUnitTest)
✅ Build successful (assembleDebug)
✅ Code formatted (formatKotlin)

## Changes
- `app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorPresenter.kt`
- `app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorUi.kt`
- `CHANGELOG.md`