### PR TITLE
fix: Pass correct operation type when launching goal components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Goals Feature Bug Fixes**
+  - Fixed goal progress screen launching wrong operation type - now correctly passes component operation (ADDITION, DIVISION, etc.) to MathPracticeScreen instead of defaulting to ADDITION
   - Fixed goal creator not persisting newly created goals to database (GoalCreatorPresenter.Event.SaveGoal handler implementation)
   - Implemented goal catalog operations: activate, delete, and archive goal handlers with proper async/error handling
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/goals/progress/GoalProgressPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/goals/progress/GoalProgressPresenter.kt
@@ -11,6 +11,7 @@ import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import dev.hossain.mathtutor.domain.model.goals.ActiveGoal
+import dev.hossain.mathtutor.domain.model.goals.GoalComponent
 import dev.hossain.mathtutor.domain.repository.GoalRepository
 import dev.hossain.mathtutor.ui.mathpractice.MathPracticeScreen
 import dev.zacsweers.metro.AppScope
@@ -46,13 +47,27 @@ class GoalProgressPresenter(
                 when (event) {
                     is GoalProgressScreen.Event.StartComponent -> {
                         currentComponentIndex = event.componentIndex
-                        // Navigate to MathPracticeScreen to start the component
-                        navigator.goTo(MathPracticeScreen())
+                        // Navigate to MathPracticeScreen with the correct operation
+                        val component = activeGoal?.goal?.components?.getOrNull(event.componentIndex)
+                        if (component is GoalComponent.OperationBased) {
+                            navigator.goTo(MathPracticeScreen(operation = component.operation))
+                        } else if (component is GoalComponent.CustomChallengeBased) {
+                            navigator.goTo(
+                                MathPracticeScreen(customChallengeId = component.challengeId),
+                            )
+                        }
                     }
 
                     GoalProgressScreen.Event.ResumeCurrentComponent -> {
-                        // Resume current component by navigating to practice
-                        navigator.goTo(MathPracticeScreen())
+                        // Resume current component by navigating to practice with correct operation
+                        val component = activeGoal?.goal?.components?.getOrNull(currentComponentIndex)
+                        if (component is GoalComponent.OperationBased) {
+                            navigator.goTo(MathPracticeScreen(operation = component.operation))
+                        } else if (component is GoalComponent.CustomChallengeBased) {
+                            navigator.goTo(
+                                MathPracticeScreen(customChallengeId = component.challengeId),
+                            )
+                        }
                     }
 
                     GoalProgressScreen.Event.Back -> {


### PR DESCRIPTION
## Problem
When a goal component with a specific operation (DIVISION, SUBTRACTION, MULTIPLICATION) was assigned and the user tapped "Start Session" on the goal progress screen, it would always open an ADDITION practice session instead of the correct operation type.

**Root Cause**: The `GoalProgressPresenter` was calling `navigator.goTo(MathPracticeScreen())` without passing the `operation` parameter, which defaults to `MathOperation.ADDITION`.

## Solution
Updated `GoalProgressPresenter` to:
1. Extract the `GoalComponent` from the active goal based on the component index
2. Check if it's an `OperationBased` component and extract its operation field
3. Pass the operation to `MathPracticeScreen(operation = component.operation)`
4. Handle both `StartComponent` and `ResumeCurrentComponent` event handlers
5. Support both `OperationBased` and `CustomChallengeBased` component types

## Changes
- **GoalProgressPresenter.kt**: 
  - Added import for `GoalComponent`
  - Updated `StartComponent` event handler to pass operation parameter
  - Updated `ResumeCurrentComponent` event handler to pass operation parameter
- **CHANGELOG.md**: Documented the fix

## Testing
- Code formatting: ✅ `./gradlew formatKotlin`
- Linting: ✅ `./gradlew lintKotlin`
- Ready for unit and integration testing

## Impact
Users can now complete goal components with specific operations (DIVISION, SUBTRACTION, MULTIPLICATION) as intended. The goal progress tracking will now correctly update for the assigned operation type rather than always tracking ADDITION.