### PR TITLE
fix: Clear active goal when archiving/deleting a goal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Goals Feature Bug Fixes**
+  - Fixed archived/deleted goals not clearing active goal state - when a goal is archived, the active goal reference is now properly deleted, preventing orphaned references from appearing on home screen
   - Fixed goal progress screen launching wrong operation type - now correctly passes component operation (ADDITION, DIVISION, etc.) to MathPracticeScreen instead of defaulting to ADDITION
   - Fixed goal creator not persisting newly created goals to database (GoalCreatorPresenter.Event.SaveGoal handler implementation)
   - Implemented goal catalog operations: activate, delete, and archive goal handlers with proper async/error handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Goals Feature Bug Fixes**
+  - Fixed goal progress screen launching wrong operation type - now correctly passes component operation (ADDITION, DIVISION, etc.) to MathPracticeScreen instead of defaulting to ADDITION
   - Fixed goal creator not persisting newly created goals to database (GoalCreatorPresenter.Event.SaveGoal handler implementation)
   - Implemented goal catalog operations: activate, delete, and archive goal handlers with proper async/error handling
 

--- a/app/src/main/java/dev/hossain/mathtutor/data/repository/GoalRepositoryImpl.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/repository/GoalRepositoryImpl.kt
@@ -107,6 +107,12 @@ class GoalRepositoryImpl(
                 goalsDao.getGoalById(goalId)
                     ?: return Result.failure(GoalError.GoalNotFound(goalId))
 
+            // Check if this goal is currently active and clear it if so
+            val activeGoal = activeGoalDao.getActiveGoalById(goalId)
+            if (activeGoal != null) {
+                activeGoalDao.delete(activeGoal)
+            }
+
             goalsDao.archiveGoal(goalId)
             Result.success(Unit)
         } catch (e: Exception) {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/goals/progress/GoalProgressPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/goals/progress/GoalProgressPresenter.kt
@@ -11,6 +11,7 @@ import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import dev.hossain.mathtutor.domain.model.goals.ActiveGoal
+import dev.hossain.mathtutor.domain.model.goals.GoalComponent
 import dev.hossain.mathtutor.domain.repository.GoalRepository
 import dev.hossain.mathtutor.ui.mathpractice.MathPracticeScreen
 import dev.zacsweers.metro.AppScope
@@ -46,13 +47,27 @@ class GoalProgressPresenter(
                 when (event) {
                     is GoalProgressScreen.Event.StartComponent -> {
                         currentComponentIndex = event.componentIndex
-                        // Navigate to MathPracticeScreen to start the component
-                        navigator.goTo(MathPracticeScreen())
+                        // Navigate to MathPracticeScreen with the correct operation
+                        val component = activeGoal?.goal?.components?.getOrNull(event.componentIndex)
+                        if (component is GoalComponent.OperationBased) {
+                            navigator.goTo(MathPracticeScreen(operation = component.operation))
+                        } else if (component is GoalComponent.CustomChallengeBased) {
+                            navigator.goTo(
+                                MathPracticeScreen(customChallengeId = component.challengeId),
+                            )
+                        }
                     }
 
                     GoalProgressScreen.Event.ResumeCurrentComponent -> {
-                        // Resume current component by navigating to practice
-                        navigator.goTo(MathPracticeScreen())
+                        // Resume current component by navigating to practice with correct operation
+                        val component = activeGoal?.goal?.components?.getOrNull(currentComponentIndex)
+                        if (component is GoalComponent.OperationBased) {
+                            navigator.goTo(MathPracticeScreen(operation = component.operation))
+                        } else if (component is GoalComponent.CustomChallengeBased) {
+                            navigator.goTo(
+                                MathPracticeScreen(customChallengeId = component.challengeId),
+                            )
+                        }
                     }
 
                     GoalProgressScreen.Event.Back -> {


### PR DESCRIPTION
## Problem
When a user deleted/archived an active goal from the parent settings screen, the goal was deleted from the catalog but the active goal reference was not cleaned up. This caused the deleted goal to still appear on the home screen in the active goal progress banner.

**Steps to Reproduce:**
1. Create and activate a goal
2. Go to parent settings (goal catalog)
3. Delete/archive the active goal
4. Navigate back to home screen
5. The deleted goal's progress banner still appears

**Root Cause:** The `archiveGoal()` method in `GoalRepositoryImpl` only archives the goal in the goals_catalog table but doesn't check or delete the corresponding entry in the active_goals table.

## Solution
Updated `GoalRepositoryImpl.archiveGoal()` to:
1. Check if the goal being archived is the currently active goal
2. If it is active, delete the active goal record before archiving the goal
3. This prevents orphaned references from appearing in the UI

## Changes
- **GoalRepositoryImpl.kt**: 
  - Added check for active goal before archiving
  - Delete active goal reference if present
- **CHANGELOG.md**: Documented the cascading delete fix

## Impact
Users can now safely delete/archive active goals from the parent settings screen without seeing orphaned references on the home screen. The active goal state is properly synchronized with the goals catalog.

## Testing Notes
- Existing tests should pass
- Manual testing: Delete an active goal and verify home screen no longer shows it