### PR TITLE
feat: Add CustomChallengeBased component support to Goal Creator

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorPresenter.kt
@@ -1,6 +1,7 @@
 package dev.hossain.mathtutor.ui.goals.creator
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -9,7 +10,9 @@ import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import dev.hossain.mathtutor.domain.model.CustomChallenge
 import dev.hossain.mathtutor.domain.model.goals.GoalComponent
+import dev.hossain.mathtutor.domain.repository.CustomChallengeRepository
 import dev.hossain.mathtutor.domain.usecase.goals.CreateGoalUseCase
 import dev.hossain.mathtutor.ui.goals.creator.GoalCreatorScreen.Event
 import dev.hossain.mathtutor.ui.goals.creator.GoalCreatorScreen.State
@@ -26,6 +29,7 @@ class GoalCreatorPresenter(
     @Assisted private val screen: GoalCreatorScreen,
     @Assisted private val navigator: Navigator,
     private val createGoalUseCase: CreateGoalUseCase,
+    private val customChallengeRepository: CustomChallengeRepository,
 ) : Presenter<State> {
     @CircuitInject(GoalCreatorScreen::class, AppScope::class)
     @AssistedFactory
@@ -46,6 +50,20 @@ class GoalCreatorPresenter(
         var components by remember { mutableStateOf<List<GoalComponent>>(emptyList()) }
         var isLoading by remember { mutableStateOf(false) }
         var error by remember { mutableStateOf<String?>(null) }
+        var availableChallenges by remember { mutableStateOf<List<CustomChallenge>>(emptyList()) }
+
+        // Load available custom challenges on composition
+        LaunchedEffect(Unit) {
+            coroutineScope.launch {
+                try {
+                    val challenges = customChallengeRepository.getAllChallenges()
+                    availableChallenges = challenges
+                    Timber.d("GoalCreator: Loaded ${challenges.size} custom challenges")
+                } catch (e: Exception) {
+                    Timber.w(e, "GoalCreator: Failed to load custom challenges")
+                }
+            }
+        }
 
         val canAdvance =
             when (currentStep) {
@@ -137,6 +155,7 @@ class GoalCreatorPresenter(
             goalTitle = goalTitle,
             goalDescription = goalDescription,
             components = components,
+            availableChallenges = availableChallenges,
             canAdvance = canAdvance,
             isLoading = isLoading,
             error = error,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorScreen.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
+import dev.hossain.mathtutor.domain.model.CustomChallenge
 import dev.hossain.mathtutor.domain.model.goals.GoalComponent
 import kotlinx.parcelize.Parcelize
 
@@ -47,6 +48,7 @@ data object GoalCreatorScreen : Screen {
         val goalTitle: String = "",
         val goalDescription: String = "",
         val components: List<GoalComponent> = emptyList(),
+        val availableChallenges: List<CustomChallenge> = emptyList(),
         val canAdvance: Boolean = false,
         val isLoading: Boolean = false,
         val error: String? = null,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/goals/creator/GoalCreatorUi.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
+import dev.hossain.mathtutor.domain.model.CustomChallenge
 import dev.hossain.mathtutor.domain.model.MathOperation
 import dev.hossain.mathtutor.domain.model.goals.GoalComponent
 import dev.hossain.mathtutor.ui.goals.creator.GoalCreatorScreen.Event
@@ -119,6 +120,7 @@ fun GoalCreatorUi(
                             components = state.components,
                             onAddComponent = { state.eventSink(Event.AddComponent(it)) },
                             onRemoveComponent = { state.eventSink(Event.RemoveComponent(it)) },
+                            availableChallenges = state.availableChallenges,
                             modifier = Modifier.fillMaxWidth(),
                         )
                     }
@@ -264,6 +266,7 @@ private fun SelectComponentsContent(
     components: List<GoalComponent>,
     onAddComponent: (GoalComponent) -> Unit,
     onRemoveComponent: (Int) -> Unit,
+    availableChallenges: List<CustomChallenge> = emptyList(),
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -276,7 +279,7 @@ private fun SelectComponentsContent(
         )
 
         Text(
-            text = "Choose which math operations your child should practice:",
+            text = "Choose which math operations and custom challenges your child should practice:",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -290,36 +293,90 @@ private fun SelectComponentsContent(
                 MathOperation.DIVISION,
             )
 
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            operations.forEach { operation ->
-                val isSelected =
-                    components.any {
-                        it is GoalComponent.OperationBased && it.operation == operation
-                    }
-                OperationButton(
-                    operation = operation,
-                    isSelected = isSelected,
-                    onClick = {
-                        if (isSelected) {
-                            onRemoveComponent(
-                                components.indexOfFirst {
-                                    it is GoalComponent.OperationBased && it.operation == operation
-                                },
-                            )
-                        } else {
-                            val component =
-                                GoalComponent.OperationBased(
-                                    operation = operation,
-                                    sessionCount = 1,
-                                )
-                            onAddComponent(component)
+        // Math Operations Section
+        if (operations.isNotEmpty()) {
+            Text(
+                text = "Math Operations",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                operations.forEach { operation ->
+                    val isSelected =
+                        components.any {
+                            it is GoalComponent.OperationBased && it.operation == operation
                         }
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                    OperationButton(
+                        operation = operation,
+                        isSelected = isSelected,
+                        onClick = {
+                            if (isSelected) {
+                                onRemoveComponent(
+                                    components.indexOfFirst {
+                                        it is GoalComponent.OperationBased && it.operation == operation
+                                    },
+                                )
+                            } else {
+                                val component =
+                                    GoalComponent.OperationBased(
+                                        operation = operation,
+                                        sessionCount = 1,
+                                    )
+                                onAddComponent(component)
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+
+        // Custom Challenges Section
+        if (availableChallenges.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Custom Challenges",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                availableChallenges.forEach { challenge ->
+                    val isSelected =
+                        components.any {
+                            it is GoalComponent.CustomChallengeBased && it.challengeId == challenge.id
+                        }
+                    CustomChallengeButton(
+                        challenge = challenge,
+                        isSelected = isSelected,
+                        onClick = {
+                            if (isSelected) {
+                                onRemoveComponent(
+                                    components.indexOfFirst {
+                                        it is GoalComponent.CustomChallengeBased && it.challengeId == challenge.id
+                                    },
+                                )
+                            } else {
+                                val component =
+                                    GoalComponent.CustomChallengeBased(
+                                        challengeId = challenge.id,
+                                        challengeTitle = challenge.title,
+                                        sessionCount = 1,
+                                    )
+                                onAddComponent(component)
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         }
 
@@ -362,6 +419,39 @@ private fun OperationButton(
     ) {
         Text(
             text = "${operation.symbol} ${operation.displayName}",
+            style = MaterialTheme.typography.labelLarge,
+        )
+    }
+}
+
+@Composable
+private fun CustomChallengeButton(
+    challenge: CustomChallenge,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.height(48.dp),
+        colors =
+            androidx.compose.material3.ButtonDefaults.buttonColors(
+                containerColor =
+                    if (isSelected) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surface
+                    },
+                contentColor =
+                    if (isSelected) {
+                        MaterialTheme.colorScheme.onSecondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+            ),
+    ) {
+        Text(
+            text = challenge.title,
             style = MaterialTheme.typography.labelLarge,
         )
     }


### PR DESCRIPTION
## Summary

This PR implements UI support for custom challenge-based goal components, resolving the critical issue where the Goal Creator only supported operation-based goals.

## Changes

### Updated Files

1. **GoalCreatorPresenter.kt**
   - Injected `CustomChallengeRepository` dependency
   - Added `LaunchedEffect` to load all available custom challenges asynchronously
   - Updated state return to include `availableChallenges` list
   - Proper error handling with Timber logging

2. **GoalCreatorScreen.kt**
   - Added `CustomChallenge` import
   - Updated `State` data class to include `availableChallenges: List<CustomChallenge> = emptyList()`

3. **GoalCreatorUi.kt**
   - Added `CustomChallenge` import
   - Enhanced `SelectComponentsContent` to support both operation and custom challenge selection
   - Separated UI into "Math Operations" and "Custom Challenges" sections with headers
   - Added new `CustomChallengeButton` composable with Material 3 secondary color scheme
   - Updated event handling for mixed component types (operations + custom challenges)

## Features

✅ Load custom challenges from repository on goal creator composition
✅ Display available custom challenges in a dedicated UI section
✅ Support mixed goal components (operations + custom challenges in same goal)
✅ Material 3 compliant styling (secondary colors for challenge buttons)
✅ Proper state management with coroutine error handling

## Testing

- [x] Kotlin formatting verified (`./gradlew formatKotlin`)
- [x] Linting passed (`./gradlew lintKotlin`)
- [x] No compilation errors
- [x] All changes follow Circuit UDF pattern and existing code structure

## Relates To

Resolves issue #2 from GOALS_FEATURE_ASSESSMENT.md: "CustomChallengeBased Components Not Supported"

## Next Steps

- Comprehensive testing of custom challenge goal creation flow
- Verify custom challenges appear in goal review step
- Test goal execution with mixed component types
