### PR TITLE
fix: Correct accuracy display in goal history (remove double multiplication)

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/ui/goals/history/GoalHistoryUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/goals/history/GoalHistoryUi.kt
@@ -172,7 +172,7 @@ private fun HistoryListView(
                 )
                 AnalyticsCard(
                     title = "Average Accuracy",
-                    value = "${String.format("%.1f", averageAccuracy * 100)}%",
+                    value = "${String.format("%.1f", averageAccuracy)}%",
                     modifier = Modifier.fillMaxWidth(),
                 )
                 AnalyticsCard(


### PR DESCRIPTION
## Summary
Fixes incorrect accuracy display in goal history screen where 100% accuracy was being shown as 10000%.

## Root Cause
The `overallAccuracy` field is stored in the 0-100 range (e.g., 95.5 for 95.5%), but the UI code was multiplying it by 100 again:
```kotlin
value = "${String.format("%.1f", averageAccuracy * 100)}%"
```

This caused the accuracy to be multiplied incorrectly:
- 100% → displayed as 10000%
- 95.5% → displayed as 9550%

## Fix
Removed the unnecessary `* 100` multiplication since the value is already in percentage form:
```kotlin
value = "${String.format("%.1f", averageAccuracy)}%"
```

## Files Changed
- `GoalHistoryUi.kt` - Fixed accuracy display formatting

## Testing
- ✅ Build successful
- ✅ No compilation errors
- ✅ Accuracy now displays correctly in goal history

## Impact
Users will now see correct accuracy percentages when viewing goal completion history (e.g., 95.5% instead of 9550%).

Related to #442 (Goals Feature Phase 4)