### PR TITLE
feat: Enhance import challenge UI with collapsible guide and state persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Import Challenge UI Improvements** - Enhanced the import challenge screen to make it easier for parents to import custom challenges
+  - New **Quick Start Guide** with step-by-step instructions (Create Challenge → Copy JSON → Paste & Save)
+  - **Step-by-step visual guide** with numbered badges and clear descriptions
+  - **Example JSON** in the input field when empty, with "Use This Example" button to help parents get started faster
+  - **Improved error messages** with friendly field names and helpful tips
+  - **Better error display** with visual hierarchy and emoji hints to guide parents
+  - **Collapsible Quick Start Guide** - Parents can collapse/expand the guide with an expand/collapse button
+  - **Persistent guide state** - App remembers if the guide was collapsed, preference is saved across sessions
+  - **Smooth animations** - Expand/collapse transitions are animated for better UX
+  - **Auto-collapse on action** - Guide automatically collapses when user clicks "Open Creator" button
 - **Firebase Test Lab Robo Script** - Added comprehensive Robo test scripts for automated UI testing in Firebase Test Lab
   - **Primary Script (robo_script.json)**: Covers first-time user experience
     - Complete onboarding flow (4 pages, grade selection, name entry)

--- a/app/src/main/java/dev/hossain/mathtutor/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/data/UserPreferencesRepository.kt
@@ -115,6 +115,21 @@ interface UserPreferencesRepository {
      * @param gradeLevel The maximum grade level to set, or null to remove limit
      */
     suspend fun setMaxGradeLevel(gradeLevel: GradeLevel?)
+
+    /**
+     * Gets whether the import challenge quick start guide is expanded.
+     * Defaults to true if not previously set.
+     *
+     * @return Flow of guide expansion state
+     */
+    val isImportGuideExpanded: Flow<Boolean>
+
+    /**
+     * Sets whether the import challenge quick start guide is expanded.
+     *
+     * @param expanded true to expand guide, false to collapse
+     */
+    suspend fun setImportGuideExpanded(expanded: Boolean)
 }
 
 @SingleIn(AppScope::class)
@@ -140,6 +155,9 @@ class UserPreferencesRepositoryImpl
             // Parent controls keys
             val PARENT_PIN_HASH = stringPreferencesKey("parent_pin_hash")
             val MAX_GRADE_LEVEL = stringPreferencesKey("max_grade_level")
+
+            // UI state keys
+            val IMPORT_GUIDE_EXPANDED = booleanPreferencesKey("import_guide_expanded")
         }
 
         override val isOnboardingCompleted: Flow<Boolean> =
@@ -319,6 +337,18 @@ class UserPreferencesRepositoryImpl
                 } else {
                     preferences.remove(PreferencesKeys.MAX_GRADE_LEVEL)
                 }
+            }
+        }
+
+        override val isImportGuideExpanded: Flow<Boolean> =
+            context.userPreferencesDataStore.data.map { preferences ->
+                preferences[PreferencesKeys.IMPORT_GUIDE_EXPANDED] ?: true
+            }
+
+        override suspend fun setImportGuideExpanded(expanded: Boolean) {
+            Timber.d("UserPreferencesRepository: Setting import guide expanded = $expanded")
+            context.userPreferencesDataStore.edit { preferences ->
+                preferences[PreferencesKeys.IMPORT_GUIDE_EXPANDED] = expanded
             }
         }
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt
@@ -42,6 +42,7 @@ class ImportChallengePresenter
         private val jsonParser: ChallengeJsonParser,
         private val challengeService: CustomChallengeService,
         private val challengeRepository: CustomChallengeRepository,
+        private val userPreferencesRepository: dev.hossain.mathtutor.data.UserPreferencesRepository,
     ) : Presenter<ImportChallengeScreen.State> {
         @CircuitInject(ImportChallengeScreen::class, AppScope::class)
         @AssistedFactory
@@ -61,6 +62,14 @@ class ImportChallengePresenter
             var previewData by remember { mutableStateOf<PreviewData?>(null) }
             var isLoading by remember { mutableStateOf(false) }
             var detectedJsonFromShare by remember { mutableStateOf(false) }
+            var isGuideExpanded by remember { mutableStateOf(true) }
+
+            // Load guide expansion state from preferences
+            LaunchedEffect(Unit) {
+                userPreferencesRepository.isImportGuideExpanded.collect { expanded ->
+                    isGuideExpanded = expanded
+                }
+            }
 
             // Initialize with shared text if provided
             LaunchedEffect(screen.prefilledJson) {
@@ -85,6 +94,7 @@ class ImportChallengePresenter
                 previewData = previewData,
                 isLoading = isLoading,
                 detectedJsonFromShare = detectedJsonFromShare,
+                isGuideExpanded = isGuideExpanded,
             ) { event ->
                 when (event) {
                     is ImportChallengeScreen.Event.JsonInputChanged -> {
@@ -243,6 +253,14 @@ class ImportChallengePresenter
 
                     ImportChallengeScreen.Event.NavigateBack -> {
                         navigator.pop()
+                    }
+
+                    ImportChallengeScreen.Event.ToggleGuideExpanded -> {
+                        isGuideExpanded = !isGuideExpanded
+                        coroutineScope.launch {
+                            userPreferencesRepository.setImportGuideExpanded(isGuideExpanded)
+                            Timber.d("Import guide expanded state toggled: $isGuideExpanded")
+                        }
                     }
                 }
             }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeScreen.kt
@@ -31,6 +31,7 @@ data class ImportChallengeScreen(
      * @property previewData Preview data if validation is successful
      * @property isLoading Whether a save operation is in progress
      * @property detectedJsonFromShare Whether JSON was detected and extracted from shared content
+     * @property isGuideExpanded Whether the quick start guide is expanded
      * @property eventSink Handler for screen events
      */
     data class State(
@@ -39,6 +40,7 @@ data class ImportChallengeScreen(
         val previewData: PreviewData?,
         val isLoading: Boolean,
         val detectedJsonFromShare: Boolean,
+        val isGuideExpanded: Boolean,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -72,6 +74,11 @@ data class ImportChallengeScreen(
          * User requested to navigate back.
          */
         data object NavigateBack : Event
+
+        /**
+         * User toggled the quick start guide expansion state.
+         */
+        data object ToggleGuideExpanded : Event
     }
 
     /**

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
@@ -89,9 +90,11 @@ fun ImportChallengeUi(
         // Auto-scroll to preview when validation is successful
         LaunchedEffect(state.validationState, state.previewData) {
             if (state.validationState is ValidationState.Valid && state.previewData != null) {
-                // Find the index of the preview item and scroll to it
+                // Scroll to preview with slower animation by adding a small delay
+                // This gives a more relaxed feel to the automatic scroll
                 // Items: 0-detectedJsonBanner (conditional), 1-guide, 2-validation success (conditional), 3-json input, 4-preview
                 val previewIndex = 4
+                kotlinx.coroutines.delay(400)
                 lazyListState.animateScrollToItem(previewIndex)
             }
         }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
@@ -4,7 +4,11 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,6 +23,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.OpenInBrowser
 import androidx.compose.material.icons.outlined.Share
@@ -93,7 +99,10 @@ fun ImportChallengeUi(
 
             // Parent information section
             item {
-                ParentInfoSection()
+                ParentInfoSection(
+                    isExpanded = state.isGuideExpanded,
+                    onToggleExpand = { state.eventSink(ImportChallengeScreen.Event.ToggleGuideExpanded) },
+                )
             }
 
             // Validation messages (shown above input field)
@@ -166,6 +175,17 @@ private fun JsonInputSection(
     onClear: () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
+    val sampleJson =
+        """
+        {
+          "type": "generated",
+          "title": "Addition Practice",
+          "subtitle": "Numbers 1-10",
+          "operation": "addition",
+          "problemCount": 10,
+          "numberRange": {"min": 1, "max": 10}
+        }
+        """.trimIndent()
 
     Card(
         modifier =
@@ -202,8 +222,50 @@ private fun JsonInputSection(
                 textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
+            // Sample JSON suggestion
+            if (jsonInput.isBlank()) {
+                Card(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth(),
+                    colors =
+                        CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                        ),
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            text = "Example JSON Format:",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+
+                        Spacer(modifier = Modifier.height(6.dp))
+
+                        Text(
+                            text = sampleJson,
+                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 4,
+                        )
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        TextButton(
+                            onClick = { onJsonChanged(sampleJson) },
+                            modifier = Modifier.align(Alignment.End),
+                        ) {
+                            Text("Use This Example", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            // Action buttons
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -259,7 +321,7 @@ private fun ValidationErrorsDisplay(errors: Map<String, String>) {
 }
 
 /**
- * Display validation errors as a section above the input field.
+ * Display validation errors as a section above the input field with helpful guidance.
  */
 @Composable
 private fun ValidationErrorsSection(errors: Map<String, String>) {
@@ -273,39 +335,76 @@ private fun ValidationErrorsSection(errors: Map<String, String>) {
                 containerColor = MaterialTheme.colorScheme.errorContainer,
             ),
     ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.Warning,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(24.dp),
-            )
+        Column(modifier = Modifier.padding(16.dp)) {
+            // Error header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Warning,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(24.dp),
+                )
 
-            Spacer(modifier = Modifier.width(12.dp))
+                Spacer(modifier = Modifier.width(12.dp))
 
-            Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = "Validation Failed",
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onErrorContainer,
                 )
+            }
 
-                Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
-                errors.forEach { (field, error) ->
+            // Detailed error messages
+            errors.forEach { (field, error) ->
+                if (field == "general" || field == "duplicate") {
+                    // General or duplicate errors show as full-width messages
                     Text(
-                        text = if (field == "general" || field == "duplicate") error else "• $field: $error",
+                        text = "⚠ $error",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                } else {
+                    // Field-specific errors show with field name
+                    Text(
+                        text = "• ${fieldDisplayName(field)}: $error",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onErrorContainer,
                     )
                 }
+                Spacer(modifier = Modifier.height(4.dp))
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Helpful hint
+            Text(
+                text = "💡 Tip: Check the JSON format and ensure all required fields are present.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f),
+            )
         }
     }
 }
+
+/**
+ * Convert field name to display-friendly format.
+ */
+private fun fieldDisplayName(field: String): String =
+    when (field) {
+        "title" -> "Challenge Title"
+        "operation" -> "Operation Type"
+        "problemCount" -> "Number of Problems"
+        "numberRange" -> "Number Range"
+        "type" -> "Challenge Type"
+        "problems" -> "Problems"
+        "subtitle" -> "Subtitle (Optional)"
+        else -> field.replaceFirstChar { it.uppercase() }
+    }
 
 /**
  * Display validation success message as a section above the input field.
@@ -538,10 +637,15 @@ private fun formatDuration(duration: Duration): String {
 }
 
 /**
- * Information section for parents with instructions and link to the worksheet creator.
+ * Information section for parents with quick-start guide and link to the worksheet creator.
+ * Can be collapsed and expanded with state persistence.
  */
 @Composable
-private fun ParentInfoSection(modifier: Modifier = Modifier) {
+private fun ParentInfoSection(
+    isExpanded: Boolean,
+    onToggleExpand: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
     val worksheetUrl = "https://math-worksheet.gohk.xyz/"
 
@@ -556,57 +660,165 @@ private fun ParentInfoSection(modifier: Modifier = Modifier) {
             ),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
+            // Header with expand/collapse button
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.Info,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(24.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "For Parents",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Quick Start Guide",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+
+                // Expand/Collapse button
+                IconButton(
+                    onClick = onToggleExpand,
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        imageVector =
+                            if (isExpanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                        contentDescription = if (isExpanded) "Collapse guide" else "Expand guide",
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            Text(
-                text = "This feature allows you to create custom math challenges for your child using JSON.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text =
-                    "You can easily generate challenge JSON using our online worksheet creator at " +
-                        "math-worksheet.gohk.xyz. Once generated, copy the JSON and paste it below.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            ElevatedButton(
-                onClick = {
-                    openWorksheetCreator(context, worksheetUrl)
-                },
-                modifier = Modifier.fillMaxWidth(),
+            // Animated content
+            AnimatedVisibility(
+                visible = isExpanded,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.OpenInBrowser,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
+                Column {
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    // Step-by-step instructions
+                    QuickStartStep(
+                        stepNumber = 1,
+                        title = "Create Challenge",
+                        description = "Use our worksheet creator to design custom math challenges",
+                        onButtonClick = {
+                            openWorksheetCreator(context, worksheetUrl)
+                            // Collapse the guide after opening the creator
+                            onToggleExpand()
+                        },
+                        buttonLabel = "Open Creator",
+                        textColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    QuickStartStep(
+                        stepNumber = 2,
+                        title = "Copy JSON",
+                        description = "The creator generates a JSON specification you can copy",
+                        onButtonClick = null,
+                        buttonLabel = null,
+                        textColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    QuickStartStep(
+                        stepNumber = 3,
+                        title = "Paste & Save",
+                        description = "Paste the JSON below, preview it, and save to your library",
+                        onButtonClick = null,
+                        buttonLabel = null,
+                        textColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Individual step in the quick-start guide.
+ */
+@Composable
+private fun QuickStartStep(
+    stepNumber: Int,
+    title: String,
+    description: String,
+    onButtonClick: (() -> Unit)?,
+    buttonLabel: String?,
+    textColor: androidx.compose.ui.graphics.Color,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top,
+    ) {
+        // Step number badge
+        Card(
+            modifier =
+                Modifier
+                    .size(32.dp),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = textColor.copy(alpha = 0.3f),
+                ),
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stepNumber.toString(),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = textColor,
                 )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Open Worksheet Creator")
+            }
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                color = textColor,
+            )
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = textColor.copy(alpha = 0.9f),
+            )
+
+            if (onButtonClick != null && buttonLabel != null) {
+                Spacer(modifier = Modifier.height(6.dp))
+
+                TextButton(
+                    onClick = onButtonClick,
+                    modifier = Modifier.height(32.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.OpenInBrowser,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(buttonLabel, style = MaterialTheme.typography.labelMedium)
+                }
             }
         }
     }
@@ -725,6 +937,7 @@ private fun ImportChallengeUiPreview() {
                     previewData = null,
                     isLoading = false,
                     detectedJsonFromShare = false,
+                    isGuideExpanded = true,
                     eventSink = {},
                 ),
         )
@@ -753,6 +966,7 @@ private fun ImportChallengeUiWithJsonPreview() {
                     previewData = null,
                     isLoading = false,
                     detectedJsonFromShare = false,
+                    isGuideExpanded = true,
                     eventSink = {},
                 ),
         )
@@ -811,6 +1025,7 @@ private fun ImportChallengeUiWithValidationSuccessPreview() {
                         ),
                     isLoading = false,
                     detectedJsonFromShare = false,
+                    isGuideExpanded = true,
                     eventSink = {},
                 ),
         )
@@ -845,6 +1060,7 @@ private fun ImportChallengeUiWithValidationErrorsPreview() {
                     previewData = null,
                     isLoading = false,
                     detectedJsonFromShare = false,
+                    isGuideExpanded = true,
                     eventSink = {},
                 ),
         )
@@ -901,6 +1117,7 @@ private fun ImportChallengeUiLoadingPreview() {
                         ),
                     isLoading = true,
                     detectedJsonFromShare = false,
+                    isGuideExpanded = true,
                     eventSink = {},
                 ),
         )
@@ -929,6 +1146,7 @@ private fun ImportChallengeUiWithShareDetectionPreview() {
                     previewData = null,
                     isLoading = false,
                     detectedJsonFromShare = true,
+                    isGuideExpanded = true,
                     eventSink = {},
                 ),
         )
@@ -962,6 +1180,7 @@ private fun ImportChallengeUiWithShareDetectionAndErrorsPreview() {
                     previewData = null,
                     isLoading = false,
                     detectedJsonFromShare = true,
+                    isGuideExpanded = true,
                     eventSink = {},
                 ),
         )

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.ExpandLess
@@ -47,6 +48,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -82,7 +84,20 @@ fun ImportChallengeUi(
         },
         modifier = modifier.fillMaxSize(),
     ) { paddingValues ->
+        val lazyListState = rememberLazyListState()
+
+        // Auto-scroll to preview when validation is successful
+        LaunchedEffect(state.validationState, state.previewData) {
+            if (state.validationState is ValidationState.Valid && state.previewData != null) {
+                // Find the index of the preview item and scroll to it
+                // Items: 0-detectedJsonBanner (conditional), 1-guide, 2-validation success (conditional), 3-json input, 4-preview
+                val previewIndex = 4
+                lazyListState.animateScrollToItem(previewIndex)
+            }
+        }
+
         LazyColumn(
+            state = lazyListState,
             modifier =
                 Modifier
                     .fillMaxSize()

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
@@ -7,6 +7,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -668,7 +669,10 @@ private fun ParentInfoSection(
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.weight(1f),
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .clickable(enabled = true, onClick = onToggleExpand),
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.Info,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
@@ -831,7 +831,6 @@ private fun QuickStartStep(
 
                 TextButton(
                     onClick = onButtonClick,
-                    modifier = Modifier.height(32.dp),
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.OpenInBrowser,
@@ -839,7 +838,7 @@ private fun QuickStartStep(
                         modifier = Modifier.size(16.dp),
                     )
                     Spacer(modifier = Modifier.width(4.dp))
-                    Text(buttonLabel, style = MaterialTheme.typography.labelMedium)
+                    Text(buttonLabel, style = MaterialTheme.typography.labelSmall)
                 }
             }
         }

--- a/app/src/test/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/devportal/DeveloperPortalPresenterTest.kt
@@ -484,6 +484,14 @@ class DeveloperPortalPresenterTest {
             largeTextEnabledFlow.value = enabled
         }
 
+        private val importGuideExpandedFlow = MutableStateFlow(true)
+
+        override val isImportGuideExpanded: Flow<Boolean> = importGuideExpandedFlow
+
+        override suspend fun setImportGuideExpanded(expanded: Boolean) {
+            importGuideExpandedFlow.value = expanded
+        }
+
         private val gameTrialAttemptsFlows = mutableMapOf<Game, MutableStateFlow<Int>>()
 
         override fun getGameTrialAttempts(game: Game): Flow<Int> = gameTrialAttemptsFlows.getOrPut(game) { MutableStateFlow(0) }

--- a/app/src/test/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsPresenterTest.kt
@@ -273,6 +273,14 @@ class ParentSettingsPresenterTest {
             largeTextFlow.value = enabled
         }
 
+        private val importGuideExpandedFlow = MutableStateFlow(true)
+
+        override val isImportGuideExpanded: Flow<Boolean> = importGuideExpandedFlow
+
+        override suspend fun setImportGuideExpanded(expanded: Boolean) {
+            importGuideExpandedFlow.value = expanded
+        }
+
         override fun getGameTrialAttempts(game: dev.hossain.mathtutor.domain.model.Game): Flow<Int> = MutableStateFlow(0)
 
         override suspend fun incrementGameTrialAttempts(game: dev.hossain.mathtutor.domain.model.Game): Int = 0

--- a/app/src/test/java/dev/hossain/mathtutor/ui/settings/AudioHapticSettingsPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/settings/AudioHapticSettingsPresenterTest.kt
@@ -211,6 +211,14 @@ class AudioHapticSettingsPresenterTest {
             analyticsEnabledFlow.value = enabled
         }
 
+        private val importGuideExpandedFlow = MutableStateFlow(true)
+
+        override val isImportGuideExpanded: Flow<Boolean> = importGuideExpandedFlow
+
+        override suspend fun setImportGuideExpanded(expanded: Boolean) {
+            importGuideExpandedFlow.value = expanded
+        }
+
         private val gameTrialAttemptsFlows = mutableMapOf<dev.hossain.mathtutor.domain.model.Game, MutableStateFlow<Int>>()
 
         override fun getGameTrialAttempts(game: dev.hossain.mathtutor.domain.model.Game): Flow<Int> =


### PR DESCRIPTION
## Overview
Enhanced the import challenge screen to make it significantly easier for parents to import custom math challenges. This PR focuses on improving the user experience through better guidance, clearer error messages, and state persistence.

## Changes Made

### Quick Start Guide
- Added a comprehensive quick start guide with step-by-step instructions
- Visual badges show numbered steps: Create Challenge → Copy JSON → Paste & Save
- Uses Material 3 color scheme with clear typography hierarchy

### Collapsible Guide
- Guide can be collapsed/expanded with an expand/collapse button in the top-right corner
- Smooth animations (expandVertically/shrinkVertically) for collapse/expand transitions
- Automatically collapses when user clicks the "Open Creator" button

### State Persistence
- Guide expansion state is saved to UserPreferences via DataStore
- Preference key: `import_guide_expanded` (defaults to `true` for new users)
- State is restored when user returns to the import page

### Example JSON
- When input field is empty, shows an example JSON format
- "Use This Example" button allows parents to quickly populate the field
- Helps parents understand the JSON structure without leaving the app

### Improved Error Messages
- Field names are converted to user-friendly display names:
  - `title` → "Challenge Title"
  - `problemCount` → "Number of Problems"
  - `numberRange` → "Number Range"
  - `operation` → "Operation Type"
- Error display includes emoji hints (⚠, 💡) for better visual guidance
- Added helpful tip: "Check the JSON format and ensure all required fields are present"

### Material 3 Compliance
- All UI components use Material 3 theme colors
- Never hardcoded colors - always uses `MaterialTheme.colorScheme.*`
- Proper typography with `MaterialTheme.typography.*`

## Files Modified
- `CHANGELOG.md` - Added detailed feature documentation
- `app/src/main/java/dev/hossain/mathtutor/data/UserPreferencesRepository.kt` - Added guide state preferences
- `app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengePresenter.kt` - Added state management
- `app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeScreen.kt` - Added guide state and event
- `app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt` - Complete UI redesign

## Testing
- ✅ Code builds successfully without errors
- ✅ All previews updated with new state parameters
- ✅ Follows project code style and Material 3 guidelines
- ✅ CHANGELOG updated per Keep a Changelog format

## Related
Improves the parent experience when importing custom math challenges from the Math Pup Worksheet Creator.