### PR TITLE
Phase 1: Text-based Hint System with wrong attempt tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Hint System (Phase 1)** - Text-based hint system to guide children toward solving problems
+  - Tracks wrong attempts per problem
+  - Shows "💡 Need help?" button after first wrong attempt
+  - Operation-specific hints for Addition, Subtraction, Multiplication, and Division
+  - Two levels of hints: gentle nudge (Level 1) and more specific guidance (Level 2)
+  - Hints encourage problem-solving without directly revealing the answer
+  - Hint state resets when moving to next problem
+  - Material 3 design with tertiaryContainer color for hint UI
 - **Smart Wrong Answer Feedback** - Enhanced feedback when children get answers wrong
   - **Varied encouragement messages** - Multiple messages like "Try again", "Not quite", "Keep going!", "Give it another shot" to reduce repetition and stay engaging
   - **Close answer detection** - When answer is off by 1, shows more encouraging messages ("Almost!", "Very close!", "You're getting there!", "So close!") for all math operation types

--- a/app/src/main/java/dev/hossain/mathtutor/domain/hint/HintProvider.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/domain/hint/HintProvider.kt
@@ -1,0 +1,89 @@
+package dev.hossain.mathtutor.domain.hint
+
+import dev.hossain.mathtutor.domain.model.MathOperation
+import dev.hossain.mathtutor.domain.model.MathProblem
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+
+/**
+ * Provides operation-specific hints to guide children toward solving math problems
+ * without directly giving away the answer.
+ *
+ * Hints are categorized by level:
+ * - Level 1: Initial gentle nudge
+ * - Level 2: More specific guidance
+ */
+interface HintProvider {
+    /**
+     * Gets the first-level hint for a problem.
+     * This is a gentle nudge to guide thinking.
+     *
+     * @param problem The math problem to provide a hint for
+     * @return A hint message (max 60 characters for readability)
+     */
+    fun getFirstHint(problem: MathProblem): String
+
+    /**
+     * Gets the second-level hint for a problem.
+     * This provides more specific guidance.
+     *
+     * @param problem The math problem to provide a hint for
+     * @return A more specific hint message
+     */
+    fun getSecondHint(problem: MathProblem): String
+}
+
+/**
+ * Default implementation of HintProvider with encouragement-based hints.
+ * Provides warm, supportive guidance that helps children problem-solve.
+ */
+@ContributesBinding(AppScope::class)
+@Inject
+class DefaultHintProvider : HintProvider {
+    override fun getFirstHint(problem: MathProblem): String =
+        when (problem.operation) {
+            MathOperation.ADDITION -> {
+                "Try counting up from ${problem.num1}"
+            }
+
+            MathOperation.SUBTRACTION -> {
+                "How many are left if you take away ${problem.num2}?"
+            }
+
+            MathOperation.MULTIPLICATION -> {
+                "You have ${problem.num1} groups of ${problem.num2}"
+            }
+
+            MathOperation.DIVISION -> {
+                "Share ${problem.num1} equally among ${problem.num2}"
+            }
+
+            MathOperation.MIXED -> {
+                ""
+            }
+        }
+
+    override fun getSecondHint(problem: MathProblem): String =
+        when (problem.operation) {
+            MathOperation.ADDITION -> {
+                "${problem.num1}... ${problem.num1 + 1}, ${problem.num1 + 2}, count on!"
+            }
+
+            MathOperation.SUBTRACTION -> {
+                "Start with ${problem.num1}, count back ${problem.num2}"
+            }
+
+            MathOperation.MULTIPLICATION -> {
+                "Add ${problem.num2} + ${problem.num2}... ${problem.num1} times"
+            }
+
+            MathOperation.DIVISION -> {
+                "Each gets the same amount. How many each?"
+            }
+
+            MathOperation.MIXED -> {
+                ""
+            }
+        }
+}

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
@@ -17,6 +17,7 @@ import dev.hossain.mathtutor.analytics.AnalyticsService
 import dev.hossain.mathtutor.audio.AudioService
 import dev.hossain.mathtutor.domain.generator.AdaptiveProblemGenerator
 import dev.hossain.mathtutor.domain.generator.ProblemGenerator
+import dev.hossain.mathtutor.domain.hint.HintProvider
 import dev.hossain.mathtutor.domain.model.Badge
 import dev.hossain.mathtutor.domain.model.DifficultyAdjustment
 import dev.hossain.mathtutor.domain.model.GradeLevel
@@ -64,6 +65,7 @@ class MathPracticePresenter
         private val hapticService: HapticService,
         private val analyticsService: AnalyticsService,
         private val customChallengeService: dev.hossain.mathtutor.domain.service.CustomChallengeService,
+        private val hintProvider: HintProvider,
     ) : Presenter<MathPracticeScreen.State> {
         @CircuitInject(MathPracticeScreen::class, AppScope::class)
         @AssistedFactory
@@ -111,6 +113,10 @@ class MathPracticePresenter
             var isAdaptiveEnabled by remember { mutableStateOf(false) }
             var userName by remember { mutableStateOf<String?>(null) }
             var customChallengeTitle by remember { mutableStateOf<String?>(null) }
+            var wrongAttempts by remember { mutableStateOf(0) }
+            var showHintButton by remember { mutableStateOf(false) }
+            var currentHintText by remember { mutableStateOf<String?>(null) }
+            var hintButtonClicked by remember { mutableStateOf(false) }
 
             /**
              * Manually deduplicates problems by removing duplicate problem strings,
@@ -345,6 +351,10 @@ class MathPracticePresenter
                 actualGradeLevel = actualGradeLevel,
                 showDifficultyChangeNotice = showDifficultyChangeNotice,
                 customChallengeTitle = customChallengeTitle,
+                wrongAttempts = wrongAttempts,
+                showHintButton = showHintButton,
+                currentHintText = currentHintText,
+                hintButtonClicked = hintButtonClicked,
             ) { event ->
                 when (event) {
                     is MathPracticeScreen.Event.NumberClicked -> {
@@ -362,6 +372,16 @@ class MathPracticePresenter
                             val userAnswer = currentAnswer.toIntOrNull()
                             val correct = userAnswer?.let { currentProblem.checkAnswer(it) } ?: false
                             isCorrect = if (userAnswer != null) correct else null
+
+                            // Track wrong attempts for hint feature
+                            if (userAnswer != null && !correct) {
+                                wrongAttempts++
+                                // Show hint button after 1st wrong attempt
+                                if (wrongAttempts >= 1) {
+                                    showHintButton = true
+                                }
+                                Timber.d("[MathPractice] Wrong attempt #$wrongAttempts for problem ${currentProblem.id}")
+                            }
 
                             // Play audio and haptic feedback based on correctness
                             if (userAnswer != null) {
@@ -426,6 +446,11 @@ class MathPracticePresenter
                             currentAnswer = ""
                             isCorrect = null
                             problemStartTime = Instant.now() // Reset timer for next problem
+                            // Reset hint state for new problem
+                            wrongAttempts = 0
+                            showHintButton = false
+                            currentHintText = null
+                            hintButtonClicked = false
                         } else {
                             // All problems completed, save session and check for badges/streak
                             val sessionEndTime = Instant.now()
@@ -618,6 +643,26 @@ class MathPracticePresenter
 
                     is MathPracticeScreen.Event.DismissDifficultyNotice -> {
                         showDifficultyChangeNotice = false
+                    }
+
+                    is MathPracticeScreen.Event.RequestHint -> {
+                        if (currentProblem != null) {
+                            val hintLevel = if (wrongAttempts <= 1) 1 else 2
+                            currentHintText =
+                                if (hintLevel == 1) {
+                                    hintProvider.getFirstHint(currentProblem)
+                                } else {
+                                    hintProvider.getSecondHint(currentProblem)
+                                }
+                            hintButtonClicked = true
+                            Timber.d("[MathPractice] Hint requested - level $hintLevel for problem ${currentProblem.id}")
+                        }
+                    }
+
+                    is MathPracticeScreen.Event.DismissHint -> {
+                        currentHintText = null
+                        hintButtonClicked = false
+                        Timber.d("[MathPractice] Hint dismissed")
                     }
                 }
             }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeScreen.kt
@@ -44,6 +44,10 @@ data class MathPracticeScreen(
         val actualGradeLevel: GradeLevel? = null,
         val showDifficultyChangeNotice: Boolean = false,
         val customChallengeTitle: String? = null,
+        val wrongAttempts: Int = 0,
+        val showHintButton: Boolean = false,
+        val currentHintText: String? = null,
+        val hintButtonClicked: Boolean = false,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -66,5 +70,9 @@ data class MathPracticeScreen(
         data object DismissBadgeDialog : Event
 
         data object DismissDifficultyNotice : Event
+
+        data object RequestHint : Event
+
+        data object DismissHint : Event
     }
 }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeUi.kt
@@ -312,6 +312,36 @@ internal fun MathPracticeUi(
                                     onNext = { state.eventSink(MathPracticeScreen.Event.NextProblem) },
                                     hapticService = hapticService,
                                 )
+
+                                // Hint button (landscape mode)
+                                if (state.showHintButton && !state.hintButtonClicked) {
+                                    Spacer(modifier = Modifier.height(12.dp))
+                                    Button(
+                                        onClick = { state.eventSink(MathPracticeScreen.Event.RequestHint) },
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .padding(horizontal = 16.dp),
+                                        colors =
+                                            ButtonDefaults.buttonColors(
+                                                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                                            ),
+                                    ) {
+                                        Text(
+                                            "💡 Need help?",
+                                            color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                        )
+                                    }
+                                }
+
+                                // Hint display card (landscape)
+                                if (state.currentHintText != null) {
+                                    Spacer(modifier = Modifier.height(12.dp))
+                                    HintCard(
+                                        hintText = state.currentHintText,
+                                        onDismiss = { state.eventSink(MathPracticeScreen.Event.DismissHint) },
+                                    )
+                                }
                             }
                         }
                     } else {
@@ -379,6 +409,36 @@ internal fun MathPracticeUi(
                                 onNext = { state.eventSink(MathPracticeScreen.Event.NextProblem) },
                                 hapticService = hapticService,
                             )
+
+                            // Hint button (appears after 1st wrong attempt)
+                            if (state.showHintButton && !state.hintButtonClicked) {
+                                Spacer(modifier = Modifier.height(12.dp))
+                                Button(
+                                    onClick = { state.eventSink(MathPracticeScreen.Event.RequestHint) },
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 16.dp),
+                                    colors =
+                                        ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                                        ),
+                                ) {
+                                    Text(
+                                        "💡 Need help?",
+                                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                    )
+                                }
+                            }
+
+                            // Hint display card
+                            if (state.currentHintText != null) {
+                                Spacer(modifier = Modifier.height(12.dp))
+                                HintCard(
+                                    hintText = state.currentHintText,
+                                    onDismiss = { state.eventSink(MathPracticeScreen.Event.DismissHint) },
+                                )
+                            }
                         }
                     }
                 }
@@ -835,5 +895,55 @@ private fun MathPracticeUiIncorrectPreview() {
                     override fun setHapticsEnabled(enabled: Boolean) {}
                 },
         )
+    }
+}
+
+/**
+ * Displays a hint card with helpful guidance text.
+ * Kids can dismiss the hint to try solving on their own.
+ */
+@Composable
+private fun HintCard(
+    hintText: String,
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth().padding(16.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "💡",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    "Hint:",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+            Text(
+                text = hintText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text("Got it!")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Overview
Implements the first phase of the hint system feature, providing operation-specific text-based hints to guide children when they answer incorrectly.

## Changes
- **HintProvider interface & DefaultHintProvider**: Operation-specific hints (Addition, Subtraction, Multiplication, Division) with two levels of guidance
- **MathPracticeScreen**: Added state tracking for wrong attempts and hint display; new events for RequestHint and DismissHint
- **MathPracticePresenter**: Handles hint logic, wrong attempt tracking, and state reset between problems
- **MathPracticeUi**: Displays hint button after first wrong attempt and hint card with Material 3 styling
- **Dependency Injection**: Registered DefaultHintProvider with Metro for app-wide availability
- **CHANGELOG.md**: Documented new feature

## Hint Behavior
- Hint button ("💡 Need help?") appears after the first wrong answer
- First hint provides a gentle nudge (e.g., "Try counting up from X")
- Second hint provides more specific guidance (e.g., "X... X+1, X+2, count on!")
- Hint state resets when moving to the next problem
- Supports all four math operations

## Testing
- All pre-commit checks passing (formatting, linting, unit tests, builds)
- Manual testing confirms hint button visibility after wrong attempts
- Hint content verified for all operations

## Closes
Implements #465 Hint System Phase 1