### PR TITLE
Fix: Display hints in modal dialogs to prevent layout cutoff

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticeUi.kt
@@ -161,6 +161,61 @@ internal fun MathPracticeUi(
         )
     }
 
+    // Text hint dialog - shown as overlay to prevent layout push
+    if (state.currentHintText != null && state.currentProblem != null) {
+        AlertDialog(
+            onDismissRequest = { state.eventSink(MathPracticeScreen.Event.DismissHint) },
+            title = { Text("💡 Hint") },
+            text = { Text(state.currentHintText) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        // Ask if they want visual hint
+                        state.eventSink(MathPracticeScreen.Event.ShowVisualHint)
+                    },
+                ) {
+                    Text("Show Visually")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { state.eventSink(MathPracticeScreen.Event.DismissHint) }) {
+                    Text("Got it")
+                }
+            },
+        )
+    }
+
+    // Visual hint dialog - shown as overlay
+    if (state.showVisualHint && state.currentProblem != null) {
+        AlertDialog(
+            onDismissRequest = { state.eventSink(MathPracticeScreen.Event.DismissVisualHint) },
+            title = { Text("🎨 Visual Hint") },
+            text = {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    DotVisualizer(
+                        operation = state.currentProblem.operation,
+                        firstNumber = state.currentProblem.num1,
+                        secondNumber = state.currentProblem.num2,
+                    )
+                    Text(
+                        text = state.currentHintText ?: "See how the problem works!",
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { state.eventSink(MathPracticeScreen.Event.DismissVisualHint) }) {
+                    Text("Got it")
+                }
+            },
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -336,15 +391,6 @@ internal fun MathPracticeUi(
                                     }
                                 }
 
-                                // Hint display card (landscape)
-                                if (state.currentHintText != null) {
-                                    Spacer(modifier = Modifier.height(12.dp))
-                                    HintCard(
-                                        hintText = state.currentHintText,
-                                        onDismiss = { state.eventSink(MathPracticeScreen.Event.DismissHint) },
-                                    )
-                                }
-
                                 // Visual hint button
                                 if (state.showHintButton && !state.hintButtonClicked) {
                                     Spacer(modifier = Modifier.height(8.dp))
@@ -364,16 +410,6 @@ internal fun MathPracticeUi(
                                             color = MaterialTheme.colorScheme.onSecondaryContainer,
                                         )
                                     }
-                                }
-
-                                // Visual hint display card (landscape)
-                                if (state.showVisualHint && state.currentProblem != null) {
-                                    Spacer(modifier = Modifier.height(12.dp))
-                                    VisualHintCard(
-                                        hintText = state.currentHintText ?: "See how the problem works!",
-                                        problem = state.currentProblem,
-                                        onDismiss = { state.eventSink(MathPracticeScreen.Event.DismissVisualHint) },
-                                    )
                                 }
                             }
                         }
@@ -464,15 +500,6 @@ internal fun MathPracticeUi(
                                 }
                             }
 
-                            // Hint display card
-                            if (state.currentHintText != null) {
-                                Spacer(modifier = Modifier.height(12.dp))
-                                HintCard(
-                                    hintText = state.currentHintText,
-                                    onDismiss = { state.eventSink(MathPracticeScreen.Event.DismissHint) },
-                                )
-                            }
-
                             // Visual hint button (portrait)
                             if (state.showHintButton && !state.hintButtonClicked) {
                                 Spacer(modifier = Modifier.height(8.dp))
@@ -492,16 +519,6 @@ internal fun MathPracticeUi(
                                         color = MaterialTheme.colorScheme.onSecondaryContainer,
                                     )
                                 }
-                            }
-
-                            // Visual hint display card (portrait)
-                            if (state.showVisualHint && state.currentProblem != null) {
-                                Spacer(modifier = Modifier.height(12.dp))
-                                VisualHintCard(
-                                    hintText = state.currentHintText ?: "See how the problem works!",
-                                    problem = state.currentProblem,
-                                    onDismiss = { state.eventSink(MathPracticeScreen.Event.DismissVisualHint) },
-                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Overview
Fixes a critical UX issue where hint cards were displayed inline and pushing content down, causing hints to be cut off and invisible at the bottom of the screen.

## Problem
- Text hints from Phase 1 and visual hints from Phase 2 were displayed as inline cards
- When hints appeared, they pushed the number pad and action buttons upward
- The hint cards extended below the visible area, getting cut off
- Users couldn't see the full hint content

## Solution
Moved hint display from inline cards to **AlertDialog overlays**:

### Changes Made
- **Text Hints (Phase 1)**: Display in a modal AlertDialog with buttons for "Show Visually" and "Got it"
- **Visual Hints (Phase 2)**: Display in a modal AlertDialog showing animated dots and text
- **Removed inline HintCard**: Deleted HintCard displays from both landscape and portrait layouts
- **Removed inline VisualHintCard**: Deleted VisualHintCard displays from both layouts

### Benefits
- ✅ Hints are always fully visible and centered on screen
- ✅ Number pad and buttons stay in the same position (no layout push)
- ✅ Cleaner interface with modal focus
- ✅ Better UX for kids - clear, distraction-reduced presentation
- ✅ No layout disruption or content cutoff
- ✅ Backward compatible with existing Phase 1 & 2 functionality

## Testing
- ✅ All Android formatting checks passed
- ✅ All linting checks passed
- ✅ All unit tests passed
- ✅ Debug build lint passed
- ✅ Debug build successful

## Files Modified
- `MathPracticeUi.kt`: Added hint dialogs, removed inline hint card displays

This fix applies to both Phase 1 (text hints) and Phase 2 (visual hints) without breaking any existing functionality.