### PR TITLE
feat: Change hint button to appear after 2 failed attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Hint messaging to be more encouraging and context-aware
 - Button placement to follow natural error recovery flow
+- **"Need help?" button timing** - Now appears after 2 failed attempts instead of 1 to allow more opportunity for independent problem-solving
 - **Test Infrastructure**: Consolidated `FakeUserPreferencesRepository` into shared `fakes` package to eliminate duplication across test files
 
   - **Modal overlay dialog** - Work breakdown displayed in AlertDialog for full visibility

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
@@ -407,8 +407,8 @@ class MathPracticePresenter
                             // Track wrong attempts for hint feature
                             if (userAnswer != null && !correct) {
                                 wrongAttempts++
-                                // Show hint button after 1st wrong attempt (if hint system is enabled)
-                                if (wrongAttempts >= 1 && isHintSystemEnabled) {
+                                // Show hint button after 2nd wrong attempt (if hint system is enabled)
+                                if (wrongAttempts >= 2 && isHintSystemEnabled) {
                                     showHintButton = true
                                 }
                                 Timber.d("[MathPractice] Wrong attempt #$wrongAttempts for problem ${currentProblem.id}")


### PR DESCRIPTION
- Updated MathPracticePresenter to show 'Need help?' button after 2nd wrong attempt instead of 1st
- Allows children more opportunity for independent problem-solving
- Updated CHANGELOG.md with this change