### PR TITLE
Move Adaptive Difficulty to Parent Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Adaptive Difficulty moved to Parent Settings**: Adaptive difficulty toggle has been relocated from the main Settings screen to the Parent Settings screen for better parental control
+  - Parents can now manage adaptive difficulty alongside other educational controls like grade limits and hint system
+  - Maintains the same functionality with improved organization of parent-controlled vs child-accessible settings
+
 ## [1.21.0] - 2026-01-01
 
 ### Added

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsPresenter.kt
@@ -68,6 +68,10 @@ class ParentSettingsPresenter
             val maxGradeLevel by preferencesRepository.maxGradeLevel.collectAsState(initial = null)
             val isHintSystemEnabled by preferencesRepository.isHintSystemEnabled.collectAsState(initial = true)
 
+            // Observe user profile for adaptive difficulty setting
+            val userProfile by userProfileRepository.getProfile().collectAsState(initial = null)
+            val adaptiveDifficultyEnabled = userProfile?.adaptiveDifficultyEnabled ?: true
+
             // Dialog states
             var showPinSetup by remember { mutableStateOf(false) }
             var showPinVerification by remember { mutableStateOf(false) }
@@ -83,6 +87,7 @@ class ParentSettingsPresenter
                 hasPinSet = pinHash != null,
                 maxGradeLevel = maxGradeLevel,
                 isHintSystemEnabled = isHintSystemEnabled,
+                adaptiveDifficultyEnabled = adaptiveDifficultyEnabled,
                 showPinSetup = showPinSetup,
                 showPinVerification = showPinVerification,
                 showPinReset = showPinReset,
@@ -314,6 +319,21 @@ class ParentSettingsPresenter
                         )
                         coroutineScope.launch {
                             preferencesRepository.setHintSystemEnabled(event.enabled)
+                        }
+                    }
+
+                    is ParentSettingsScreen.Event.AdaptiveDifficultyToggled -> {
+                        Timber.d("ParentSettings: Adaptive difficulty toggled - enabled=${event.enabled}")
+                        analyticsService.logEvent(
+                            eventName = AnalyticsEvent.SETTINGS_CHANGED,
+                            parameters =
+                                mapOf(
+                                    "setting_name" to "adaptive_difficulty",
+                                    "setting_value" to event.enabled.toString(),
+                                ),
+                        )
+                        coroutineScope.launch {
+                            userProfileRepository.updateAdaptiveDifficulty(event.enabled)
                         }
                     }
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsScreen.kt
@@ -28,6 +28,8 @@ data object ParentSettingsScreen : Screen {
      *
      * @property hasPinSet Whether a parent PIN has been configured
      * @property maxGradeLevel The maximum grade level children can select (null = unlimited)
+     * @property isHintSystemEnabled Whether the hint system is enabled
+     * @property adaptiveDifficultyEnabled Whether adaptive difficulty is enabled
      * @property showPinSetup Whether to show the PIN setup dialog
      * @property showPinVerification Whether to show PIN verification dialog
      * @property showPinReset Whether to show PIN reset dialog (requires old PIN)
@@ -41,6 +43,7 @@ data object ParentSettingsScreen : Screen {
         val hasPinSet: Boolean,
         val maxGradeLevel: GradeLevel?,
         val isHintSystemEnabled: Boolean,
+        val adaptiveDifficultyEnabled: Boolean,
         val showPinSetup: Boolean,
         val showPinVerification: Boolean,
         val showPinReset: Boolean,
@@ -163,6 +166,15 @@ data object ParentSettingsScreen : Screen {
          * @property enabled Whether to enable or disable the hint system
          */
         data class HintSystemToggled(
+            val enabled: Boolean,
+        ) : Event
+
+        /**
+         * User toggled adaptive difficulty on/off.
+         *
+         * @property enabled Whether to enable or disable adaptive difficulty
+         */
+        data class AdaptiveDifficultyToggled(
             val enabled: Boolean,
         ) : Event
 

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsUi.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.outlined.LockOpen
 import androidx.compose.material.icons.outlined.School
+import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -130,6 +131,14 @@ fun ParentSettingsUi(
                 isHintSystemEnabled = state.isHintSystemEnabled,
                 onToggleHintSystem = { enabled ->
                     state.eventSink(ParentSettingsScreen.Event.HintSystemToggled(enabled))
+                },
+            )
+
+            // Adaptive Difficulty Card
+            AdaptiveDifficultyCard(
+                isAdaptiveDifficultyEnabled = state.adaptiveDifficultyEnabled,
+                onToggleAdaptiveDifficulty = { enabled ->
+                    state.eventSink(ParentSettingsScreen.Event.AdaptiveDifficultyToggled(enabled))
                 },
             )
 
@@ -511,6 +520,101 @@ private fun HintSystemCard(
     }
 }
 
+/**
+ * Card for controlling adaptive difficulty.
+ *
+ * Allows parents to enable or disable adaptive difficulty, which adjusts problem
+ * difficulty based on the child's performance.
+ */
+@Composable
+private fun AdaptiveDifficultyCard(
+    isAdaptiveDifficultyEnabled: Boolean,
+    onToggleAdaptiveDifficulty: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Tune,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Column {
+                        Text(
+                            text = \"Adaptive Difficulty\",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Text(
+                            text =
+                                if (isAdaptiveDifficultyEnabled) \"Enabled\" else \"Disabled\",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            Text(
+                text =
+                    \"When enabled, problem difficulty adjusts automatically based on performance. \" +
+                        \"When disabled, problems remain at the selected grade level.\",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedButton(
+                    onClick = { onToggleAdaptiveDifficulty(false) },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(\"Disable\")
+                }
+                Button(
+                    onClick = { onToggleAdaptiveDifficulty(true) },
+                    modifier = Modifier.weight(1f),
+                    colors =
+                        if (isAdaptiveDifficultyEnabled) {
+                            androidx.compose.material3.ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                            )
+                        } else {
+                            androidx.compose.material3.ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            )
+                        },
+                ) {
+                    Text(\"Enable\")
+                }
+            }
+        }
+    }
+}
+
 // Preview composables
 @Preview(showBackground = true)
 @Composable
@@ -522,6 +626,7 @@ private fun ParentSettingsUiPreview() {
                     hasPinSet = false,
                     maxGradeLevel = null,
                     isHintSystemEnabled = true,
+                    adaptiveDifficultyEnabled = true,
                     showPinSetup = false,
                     showPinVerification = false,
                     showPinReset = false,
@@ -545,6 +650,7 @@ private fun ParentSettingsUiWithPinSetPreview() {
                     hasPinSet = true,
                     maxGradeLevel = GradeLevel.GRADE_2,
                     isHintSystemEnabled = true,
+                    adaptiveDifficultyEnabled = true,
                     showPinSetup = false,
                     showPinVerification = false,
                     showPinReset = false,
@@ -568,6 +674,7 @@ private fun ParentSettingsUiWithOptionsExpandedPreview() {
                     hasPinSet = true,
                     maxGradeLevel = GradeLevel.GRADE_1,
                     isHintSystemEnabled = true,
+                    adaptiveDifficultyEnabled = false,
                     showPinSetup = false,
                     showPinVerification = false,
                     showPinReset = false,
@@ -591,6 +698,7 @@ private fun ParentSettingsUiWithPinSetupDialogPreview() {
                     hasPinSet = false,
                     maxGradeLevel = null,
                     isHintSystemEnabled = true,
+                    adaptiveDifficultyEnabled = true,
                     showPinSetup = true,
                     showPinVerification = false,
                     showPinReset = false,
@@ -614,6 +722,7 @@ private fun ParentSettingsUiWithGradeLimitDialogPreview() {
                     hasPinSet = true,
                     maxGradeLevel = null,
                     isHintSystemEnabled = true,
+                    adaptiveDifficultyEnabled = true,
                     showPinSetup = false,
                     showPinVerification = false,
                     showPinReset = false,
@@ -637,6 +746,7 @@ private fun ParentSettingsUiWithPinVerificationDialogPreview() {
                     hasPinSet = true,
                     maxGradeLevel = GradeLevel.GRADE_2,
                     isHintSystemEnabled = true,
+                    adaptiveDifficultyEnabled = false,
                     showPinSetup = false,
                     showPinVerification = true,
                     showPinReset = false,
@@ -660,6 +770,7 @@ private fun ParentSettingsUiWithForgotPinDialogPreview() {
                     hasPinSet = true,
                     maxGradeLevel = GradeLevel.GRADE_1,
                     isHintSystemEnabled = true,
+                    adaptiveDifficultyEnabled = true,
                     showPinSetup = false,
                     showPinVerification = false,
                     showPinReset = false,

--- a/app/src/main/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/parentsettings/ParentSettingsUi.kt
@@ -559,13 +559,13 @@ private fun AdaptiveDifficultyCard(
                     )
                     Column {
                         Text(
-                            text = \"Adaptive Difficulty\",
+                            text = "Adaptive Difficulty",
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onSurface,
                         )
                         Text(
                             text =
-                                if (isAdaptiveDifficultyEnabled) \"Enabled\" else \"Disabled\",
+                                if (isAdaptiveDifficultyEnabled) "Enabled" else "Disabled",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -575,8 +575,8 @@ private fun AdaptiveDifficultyCard(
 
             Text(
                 text =
-                    \"When enabled, problem difficulty adjusts automatically based on performance. \" +
-                        \"When disabled, problems remain at the selected grade level.\",
+                    "When enabled, problem difficulty adjusts automatically based on performance. " +
+                        "When disabled, problems remain at the selected grade level.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -592,7 +592,7 @@ private fun AdaptiveDifficultyCard(
                     onClick = { onToggleAdaptiveDifficulty(false) },
                     modifier = Modifier.weight(1f),
                 ) {
-                    Text(\"Disable\")
+                    Text("Disable")
                 }
                 Button(
                     onClick = { onToggleAdaptiveDifficulty(true) },
@@ -608,7 +608,7 @@ private fun AdaptiveDifficultyCard(
                             )
                         },
                 ) {
-                    Text(\"Enable\")
+                    Text("Enable")
                 }
             }
         }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsPresenter.kt
@@ -114,21 +114,6 @@ class SettingsPresenter
                         navigator.goTo(dev.hossain.mathtutor.ui.devportal.DeveloperPortalScreen)
                     }
 
-                    is SettingsScreen.Event.ToggleAdaptiveDifficulty -> {
-                        Timber.d("SettingsScreen: Toggle adaptive difficulty - enabled=${event.enabled}")
-                        analyticsService.logEvent(
-                            eventName = AnalyticsEvent.SETTINGS_CHANGED,
-                            parameters =
-                                mapOf(
-                                    AnalyticsParam.SETTING_NAME to "adaptive_difficulty",
-                                    AnalyticsParam.SETTING_VALUE to event.enabled.toString(),
-                                ),
-                        )
-                        scope.launch {
-                            userProfileRepository.updateAdaptiveDifficulty(event.enabled)
-                        }
-                    }
-
                     is SettingsScreen.Event.SaveName -> {
                         Timber.d("SettingsScreen: Saving name - ${event.name}")
                         analyticsService.logEvent(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsScreen.kt
@@ -53,13 +53,6 @@ data object SettingsScreen : Screen {
         data object ChangeGradeClicked : Event
 
         /**
-         * User toggled the adaptive difficulty switch.
-         */
-        data class ToggleAdaptiveDifficulty(
-            val enabled: Boolean,
-        ) : Event
-
-        /**
          * User saved a new name from the name edit dialog.
          */
         data class SaveName(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
@@ -169,14 +169,6 @@ fun SettingsUi(
                         onChangeGradeClick = { state.eventSink(SettingsScreen.Event.ChangeGradeClicked) },
                     )
 
-                    // Adaptive difficulty section
-                    AdaptiveDifficultySection(
-                        enabled = state.profile?.adaptiveDifficultyEnabled ?: true,
-                        onToggle = { enabled ->
-                            state.eventSink(SettingsScreen.Event.ToggleAdaptiveDifficulty(enabled))
-                        },
-                    )
-
                     // Divider
                     HorizontalDivider(
                         modifier = Modifier.padding(vertical = 8.dp),
@@ -367,70 +359,6 @@ private fun ProfileField(
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        }
-    }
-}
-
-/**
- * Adaptive difficulty section with toggle switch.
- */
-@Composable
-private fun AdaptiveDifficultySection(
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-            ),
-        elevation =
-            CardDefaults.cardElevation(
-                defaultElevation = 2.dp,
-            ),
-    ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Tune,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    text = "Adaptive Difficulty",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = "Adjust difficulty based on performance",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    )
-                }
-                Switch(
-                    checked = enabled,
-                    onCheckedChange = onToggle,
-                )
-            }
         }
     }
 }

--- a/app/src/test/java/dev/hossain/mathtutor/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/dev/hossain/mathtutor/ui/settings/SettingsScreenTest.kt
@@ -136,15 +136,6 @@ class SettingsScreenTest {
     }
 
     @Test
-    fun event_toggleAdaptiveDifficulty_createsCorrectEvent() {
-        // When
-        val event = SettingsScreen.Event.ToggleAdaptiveDifficulty(true)
-
-        // Then
-        assertThat(event.enabled).isTrue()
-    }
-
-    @Test
     fun event_saveName_createsCorrectEvent() {
         // When
         val event = SettingsScreen.Event.SaveName("John")
@@ -247,16 +238,15 @@ class SettingsScreenTest {
             )
 
         // When
-        state.eventSink(SettingsScreen.Event.ToggleAdaptiveDifficulty(false))
+        state.eventSink(SettingsScreen.Event.BackClicked)
 
         // Then
         assertThat(receivedEvent).isNotNull()
-        assertThat(receivedEvent is SettingsScreen.Event.ToggleAdaptiveDifficulty).isTrue()
-        assertThat((receivedEvent as SettingsScreen.Event.ToggleAdaptiveDifficulty).enabled).isFalse()
+        assertThat(receivedEvent is SettingsScreen.Event.BackClicked).isTrue()
     }
 
     @Test
-    fun state_withAdaptiveDifficultyEnabled_hasCorrectValue() {
+    fun state_withProfileData_hasCorrectValue() {
         // Given
         val profile =
             UserProfile(


### PR DESCRIPTION
## Summary
Relocates the Adaptive Difficulty toggle from the main Settings screen to the Parent Settings screen for better parental control.

## Changes
- **Moved adaptive difficulty control to Parent Settings**: Parents can now manage adaptive difficulty alongside other educational controls like grade limits and hint system
- **Improved settings organization**: Separates parent-controlled settings from child-accessible settings
- **Maintains existing functionality**: Same adaptive difficulty behavior, just better organized

## Implementation Details
- Added `adaptiveDifficultyEnabled` state to `ParentSettingsScreen`
- Created new `AdaptiveDifficultyCard` component following existing UI patterns
- Removed adaptive difficulty controls from main `SettingsScreen`
- Updated presenter logic to handle the new event flow
- Added analytics tracking for the toggle action

## Testing
- ✅ All unit tests passing
- ✅ Compilation successful
- ✅ Code formatting verified

## Checklist
- [x] Code follows project style guidelines
- [x] Tests updated and passing
- [x] CHANGELOG.md updated
- [x] Material 3 design system followed
- [x] Circuit UDF patterns maintained