### PR TITLE
Release 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-01-02
+
 ### Added
 - **Math Pup Stickers for Help Dialogs**: Added themed sticker illustrations to enhance help features
   - "Need Help" dialog now displays friendly Math Pup teaching sticker
@@ -2213,7 +2215,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied proper system bars insets for edge-to-edge display on onboarding screen
 - Fixed onboarding navigation to properly navigate to MathPracticeScreen after completion
 
-[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.21.0...HEAD
+[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.22.0...HEAD
+[1.22.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.21.0...1.22.0
 [1.21.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.20.0...1.21.0
 [1.20.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.19.0...1.20.0
 [1.19.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.18.0...1.19.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "dev.hossain.mathtutor"
         minSdk = 28
         targetSdk = 36
-        versionCode = 24
-        versionName = "1.21.0"
+        versionCode = 25
+        versionName = "1.22.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.22.0

This release includes enhancements to the hint system with themed Math Pup stickers, adaptive difficulty improvements, and better subtraction visualizations.

### ✨ New Features
- **Math Pup Stickers for Help Dialogs**: Enhanced hint system with engaging mascot illustrations
  - Teaching sticker appears in "Need Help" dialog
  - Juggling balls sticker appears in "Show Visually" dialog
  - Adaptive sizing for tablets and foldables (120dp/100dp → 180dp/150dp on ≥600dp screens)
  - Makes learning more engaging for K-2 children

### 🔧 Improvements
- **Adaptive Difficulty Relocated**: Moved to Parent Settings for better parental control
  - Organized alongside grade limits and hint system controls
  - Maintains same functionality with improved UX

- **Enhanced Subtraction Visual Hints**: More intuitive "taking away" visualization
  - All dots appear first, then subtracted dots smoothly fade to dimmed state
  - 1-second animation helps children understand subtraction concept
  - Updated hint text: "Start with X, then take away Y. Count what's left!"
  - Clearer visual feedback with bright/dim dot distinction

### 📝 Version Info
- **Version**: 1.22.0 (versionCode 25)
- **Date**: January 2, 2026

### 🔗 Changes
See [CHANGELOG.md](https://github.com/hossain-khan/kids-math-tutor/blob/release/1.22.0/CHANGELOG.md#1220---2026-01-02) for complete details.

---

**After merge**: Tag as `1.22.0` and create GitHub release.