### PR TITLE
Fix ProGuard configuration - Remove unnecessary keep rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ google-services.json
 *.salive
 temp-
 temp*/*
+*.aab
+app/release/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **ProGuard Configuration Cleanup**: Removed overly aggressive ProGuard rules that were keeping unnecessary code
+  - Removed blanket `-keep class com.slack.circuit.** { *; }` rule (only keeping interfaces)
+  - Fixed Circuit package references to use correct runtime package names (e.g., `com.slack.circuit.runtime.CircuitUiState`)
+  - Removed unnecessary Firebase, Room, Compose, WorkManager, DataStore, and Media3 keep rules (R8 handles these automatically)
+  - Removed blanket `-keep class dev.hossain.mathtutor.** { *; }` rule (keeping only specific domain models and DI-related members)
+  - Removed unnecessary `-keep class dev.hossain.mathtutor.ui.** { *; }` rule (Compose handles UI code preservation)
+  - Added `.aab` and `app/release/**` to `.gitignore` to exclude release artifacts from version control
+  - Results in smaller APK/AAB size and improved build optimization
+
 ## [1.22.0] - 2026-01-02
 
 ### Added

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,14 +23,13 @@
 # ============================================================================
 # Circuit UDF Framework - Keep all Circuit classes and related code
 # ============================================================================
--keep class com.slack.circuit.** { *; }
 -keep interface com.slack.circuit.** { *; }
--keepclassmembers class * implements com.slack.circuit.ui.CircuitUiState { *; }
--keepclassmembers class * implements com.slack.circuit.ui.CircuitUiEvent { *; }
+-keepclassmembers class * implements com.slack.circuit.runtime.CircuitUiState { *; }
+-keepclassmembers class * implements com.slack.circuit.runtime.CircuitUiEvent { *; }
 
 # Circuit codegen generated classes
--keep class dev.hossain.mathtutor.** implements com.slack.circuit.ui.Presenter { *; }
--keep class dev.hossain.mathtutor.** implements com.slack.circuit.foundation.Screen { *; }
+-keep class dev.hossain.mathtutor.** implements com.slack.circuit.runtime.presenter.Presenter { *; }
+-keep class dev.hossain.mathtutor.** implements com.slack.circuit.runtime.screen.Screen { *; }
 
 # Circuit may reference Dagger Hilt annotations (even with Metro) - ignore missing references
 -dontwarn dagger.hilt.GeneratesRootInput
@@ -40,7 +39,6 @@
 # ============================================================================
 -keep class com.zacsweers.metro.** { *; }
 -keep interface com.zacsweers.metro.** { *; }
--keep class dev.hossain.mathtutor.** { *; }
 -keepclassmembers class * { 
     @javax.inject.Inject <init>(...); 
     @javax.inject.Inject <fields>;
@@ -57,51 +55,6 @@
 -keepclassmembers class * implements kotlinx.serialization.KSerializer {
     *** objectSerializer(...);
 }
-
-# ============================================================================
-# Firebase - Keep Firebase classes and configuration
-# ============================================================================
--keep class com.google.firebase.** { *; }
--keep class com.google.firebase.analytics.** { *; }
--keep class com.google.firebase.auth.** { *; }
--keep class com.google.firebase.crashlytics.** { *; }
--keepclassmembers class com.google.firebase.** { *; }
-
-# ============================================================================
-# Room Database - Keep database classes and migrations
-# ============================================================================
--keep class androidx.room.** { *; }
--keep interface androidx.room.** { *; }
--keep class dev.hossain.mathtutor.data.local.** { *; }
--keepclassmembers class dev.hossain.mathtutor.data.local.** { *; }
-
-# ============================================================================
-# Jetpack Compose - Keep Compose runtime and related classes
-# ============================================================================
--keep class androidx.compose.runtime.** { *; }
--keep class androidx.compose.ui.** { *; }
--keep class androidx.compose.foundation.** { *; }
--keep class androidx.compose.material3.** { *; }
--keepclasseswithmembernames class androidx.compose.** {
-    native <methods>;
-}
-
-# ============================================================================
-# WorkManager - Keep WorkManager classes and workers
-# ============================================================================
--keep class androidx.work.** { *; }
--keep class dev.hossain.mathtutor.work.** { *; }
-
-# ============================================================================
-# DataStore - Keep DataStore classes
-# ============================================================================
--keep class androidx.datastore.** { *; }
-
-# ============================================================================
-# Media3/ExoPlayer - Keep media playback classes
-# ============================================================================
--keep class androidx.media3.** { *; }
--keep class com.google.android.exoplayer2.** { *; }
 
 # ============================================================================
 # Reflection-based code - Keep classes that use reflection
@@ -125,7 +78,6 @@
 # Data classes and model classes - Keep constructors and properties
 # ============================================================================
 -keep class dev.hossain.mathtutor.domain.model.** { *; }
--keep class dev.hossain.mathtutor.ui.** { *; }
 
 # ============================================================================
 # Remove logging in release builds (optional but recommended)


### PR DESCRIPTION
## Summary
This PR cleans up overly aggressive ProGuard rules that were keeping unnecessary code in the release build, resulting in a larger APK/AAB size than needed.

## Changes

### ProGuard Rules Cleanup (`proguard-rules.pro`)

**Removed unnecessary blanket keep rules:**
- ❌ `-keep class com.slack.circuit.** { *; }` - Only keeping interfaces now
- ❌ `-keep class dev.hossain.mathtutor.** { *; }` - Too broad, only keeping specific domain models
- ❌ `-keep class dev.hossain.mathtutor.ui.** { *; }` - Compose handles UI preservation
- ❌ Firebase, Room, Compose, WorkManager, DataStore, Media3 keep rules - R8 handles these automatically

**Fixed Circuit package references:**
- ✅ Updated to correct runtime package names:
  - `com.slack.circuit.runtime.CircuitUiState`
  - `com.slack.circuit.runtime.CircuitUiEvent`
  - `com.slack.circuit.runtime.presenter.Presenter`
  - `com.slack.circuit.runtime.screen.Screen`

**Kept essential rules:**
- ✅ Circuit interfaces for UDF architecture
- ✅ Metro DI annotations (`@Inject`, `@ContributesBinding`)
- ✅ Kotlinx Serialization
- ✅ Domain models (`dev.hossain.mathtutor.domain.model.**`)

### .gitignore Updates
- Added `*.aab` to exclude Android App Bundles
- Added `app/release/**` to exclude release build artifacts

## Benefits
- 📦 **Smaller APK/AAB size** - Removed unnecessary code bloat
- ⚡ **Better R8 optimization** - Allows R8 to do its job properly
- 🔧 **Correct package references** - Fixed outdated Circuit package names
- 🧹 **Cleaner version control** - Excluded release artifacts

## Testing
- ✅ Built release APK/AAB successfully
- ✅ App functionality verified (all features working)
- ✅ No ProGuard-related crashes observed

## Checklist
- [x] ProGuard rules cleaned up and tested
- [x] Release build tested
- [x] CHANGELOG.md updated
- [x] .gitignore updated