### PR TITLE
Release 1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.1] - 2026-01-02
+
 ### Added
 - **HomeScreen Adaptive Layout - Phase 4**: Complete tablet-optimized layouts with responsive grids
   - **Responsive Quick Stats Grid**: Adaptive column layout based on screen size
@@ -2239,7 +2241,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied proper system bars insets for edge-to-edge display on onboarding screen
 - Fixed onboarding navigation to properly navigate to MathPracticeScreen after completion
 
-[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.22.0...HEAD
+[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.22.1...HEAD
+[1.22.1]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.22.0...1.22.1
 [1.22.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.21.0...1.22.0
 [1.21.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.20.0...1.21.0
 [1.20.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.19.0...1.20.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "dev.hossain.mathtutor"
         minSdk = 28
         targetSdk = 36
-        versionCode = 25
-        versionName = "1.22.0"
+        versionCode = 26
+        versionName = "1.22.1"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.22.1

This patch release includes tablet UI optimizations and ProGuard configuration improvements for better performance and smaller app size.

### ✨ New Features
- **HomeScreen Adaptive Layout - Phase 4**: Complete tablet-optimized layouts with responsive grids
  - **Responsive Quick Stats Grid**: Adaptive column layout based on screen size
    - Compact (<600dp): Single column vertical layout
    - Medium (600-840dp): 2-column grid with problems and accuracy stats
    - Expanded (>840dp): 3-column grid with problems, accuracy, and sessions count
  - **Responsive Badges Section**: Adaptive badge grid for optimal display
    - Compact: 3 badges per row (phones)
    - Medium: 5 badges per row (small tablets)
    - Expanded: 6 badges per row (large tablets)
  - Enhanced visual hierarchy with improved spacing for larger screens
  - All layouts maintain Material 3 design principles with proper touch targets

### 🐛 Bug Fixes
- **ProGuard Configuration Cleanup**: Optimized release build configuration
  - Removed overly aggressive keep rules for Circuit, Firebase, Room, Compose, WorkManager, DataStore, and Media3
  - Fixed Circuit package references to use correct runtime package names
  - R8 now properly optimizes the app resulting in smaller APK/AAB size
  - Added release artifacts to `.gitignore` (`*.aab`, `app/release/**`)

### 📝 Version Info
- **Version**: 1.22.1 (versionCode 26)
- **Date**: January 2, 2026

### 🔗 Changes
See [CHANGELOG.md](https://github.com/hossain-khan/kids-math-tutor/blob/release/1.22.1/CHANGELOG.md#1221---2026-01-02) for complete details.

---

**After merge**: Tag as `1.22.1` and create GitHub release.