### PR TITLE
Fix adaptive layout issues in grade selection screen

### DIFF
--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -478,7 +478,7 @@ fun GradeSelectionUi(
                                     .fillMaxWidth()
                                     .height(gridHeight),
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
-                            verticalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(verticalSpacing),
                             userScrollEnabled = false, // Parent Column handles scrolling
                         ) {
                             items(state.availableGrades) { gradeLevel ->

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -462,7 +462,8 @@ fun GradeSelectionUi(
                             }
 
                         // Calculate grid height based on number of rows needed
-                        val numColumns = if (isLandscape) 2 else 1 // Simplified assumption
+                        // LazyVerticalGrid requires height constraint when inside scrollable parent
+                        val numColumns = if (isLandscape) 2 else 1
                         val numRows = (state.availableGrades.size + numColumns - 1) / numColumns // Ceiling division
                         val cardHeight = 150.dp
                         val verticalSpacing = 16.dp
@@ -476,6 +477,8 @@ fun GradeSelectionUi(
                                     .height(gridHeight),
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
                             verticalArrangement = Arrangement.spacedBy(16.dp),
+                            userScrollEnabled = false, // Parent Column handles scrolling
+                            contentPadding = PaddingValues(bottom = 8.dp), // Extra space for card shadow
                         ) {
                             items(state.availableGrades) { gradeLevel ->
                                 GradeCard(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -454,16 +454,16 @@ fun GradeSelectionUi(
 
                         // Use LazyVerticalGrid for adaptive layout
                         // In landscape mode, limit to 2 columns to prevent text overflow
+                        val numColumns = if (isLandscape) 2 else 1
                         val gridColumns =
                             if (isLandscape) {
-                                GridCells.Fixed(2)
+                                GridCells.Fixed(numColumns)
                             } else {
                                 GridCells.Adaptive(minSize = MIN_GRADE_CARD_WIDTH)
                             }
 
                         // Calculate grid height based on number of rows needed
                         // LazyVerticalGrid requires height constraint when inside scrollable parent
-                        val numColumns = if (isLandscape) 2 else 1
                         val numRows = (state.availableGrades.size + numColumns - 1) / numColumns // Ceiling division
                         val cardHeight = 150.dp
                         val verticalSpacing = 16.dp
@@ -474,7 +474,6 @@ fun GradeSelectionUi(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .padding(vertical = 8.dp) // Extra space for card shadows on top/bottom
                                     .height(gridHeight),
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
                             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -461,12 +461,19 @@ fun GradeSelectionUi(
                                 GridCells.Adaptive(minSize = MIN_GRADE_CARD_WIDTH)
                             }
 
+                        // Calculate grid height based on number of rows needed
+                        val numColumns = if (isLandscape) 2 else 1 // Simplified assumption
+                        val numRows = (state.availableGrades.size + numColumns - 1) / numColumns // Ceiling division
+                        val cardHeight = 150.dp
+                        val verticalSpacing = 16.dp
+                        val gridHeight = (cardHeight * numRows) + (verticalSpacing * (numRows - 1).coerceAtLeast(0))
+
                         LazyVerticalGrid(
                             columns = gridColumns,
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .height((state.availableGrades.size * 170).dp), // Approximate height for all cards
+                                    .height(gridHeight),
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
                             verticalArrangement = Arrangement.spacedBy(16.dp),
                         ) {

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -90,6 +90,8 @@ import timber.log.Timber
 import java.time.Instant
 
 private val MIN_GRADE_CARD_WIDTH: Dp = 200.dp
+private val GRADE_CARD_HEIGHT: Dp = 150.dp
+private val GRADE_CARD_VERTICAL_PADDING: Dp = 4.dp
 
 /**
  * Circuit screen for grade selection during onboarding or from settings.
@@ -465,9 +467,9 @@ fun GradeSelectionUi(
                         // Calculate grid height based on number of rows needed
                         // LazyVerticalGrid requires height constraint when inside scrollable parent
                         val numRows = (state.availableGrades.size + numColumns - 1) / numColumns // Ceiling division
-                        val cardHeight = 158.dp // 150dp card + 8dp vertical padding (4dp top + 4dp bottom)
+                        val cardHeightWithPadding = GRADE_CARD_HEIGHT + (GRADE_CARD_VERTICAL_PADDING * 2)
                         val verticalSpacing = 16.dp
-                        val gridHeight = (cardHeight * numRows) + (verticalSpacing * (numRows - 1).coerceAtLeast(0))
+                        val gridHeight = (cardHeightWithPadding * numRows) + (verticalSpacing * (numRows - 1).coerceAtLeast(0))
 
                         LazyVerticalGrid(
                             columns = gridColumns,
@@ -516,8 +518,8 @@ private fun GradeCard(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(vertical = 4.dp)
-                .height(150.dp),
+                .padding(vertical = GRADE_CARD_VERTICAL_PADDING)
+                .height(GRADE_CARD_HEIGHT),
         border =
             if (isSelected) {
                 BorderStroke(3.dp, MaterialTheme.colorScheme.primary)

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -91,7 +91,7 @@ import java.time.Instant
 
 private val MIN_GRADE_CARD_WIDTH: Dp = 200.dp
 private val GRADE_CARD_HEIGHT: Dp = 150.dp
-private val GRADE_CARD_VERTICAL_PADDING: Dp = 4.dp
+private val GRADE_CARD_VERTICAL_PADDING: Dp = 8.dp
 
 /**
  * Circuit screen for grade selection during onboarding or from settings.
@@ -468,7 +468,7 @@ fun GradeSelectionUi(
                         // LazyVerticalGrid requires height constraint when inside scrollable parent
                         val numRows = (state.availableGrades.size + numColumns - 1) / numColumns // Ceiling division
                         val cardHeightWithPadding = GRADE_CARD_HEIGHT + (GRADE_CARD_VERTICAL_PADDING * 2)
-                        val verticalSpacing = 16.dp
+                        val verticalSpacing = 4.dp
                         val gridHeight = (cardHeightWithPadding * numRows) + (verticalSpacing * (numRows - 1).coerceAtLeast(0))
 
                         LazyVerticalGrid(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -474,11 +474,11 @@ fun GradeSelectionUi(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
+                                    .padding(vertical = 8.dp) // Extra space for card shadows on top/bottom
                                     .height(gridHeight),
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
                             verticalArrangement = Arrangement.spacedBy(16.dp),
                             userScrollEnabled = false, // Parent Column handles scrolling
-                            contentPadding = PaddingValues(bottom = 8.dp), // Extra space for card shadow
                         ) {
                             items(state.availableGrades) { gradeLevel ->
                                 GradeCard(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -444,8 +444,6 @@ fun GradeSelectionUi(
                             textAlign = TextAlign.Center,
                         )
 
-                        Spacer(modifier = Modifier.height(8.dp))
-
                         // Display grade cards using adaptive grid based on availability (respecting parent limits)
                         val gradeDescriptions =
                             mapOf(

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -342,6 +342,8 @@ fun GradeSelectionUi(
                     .padding(paddingValues),
         ) {
             val screenWidth = maxWidth
+            val screenHeight = maxHeight
+            val isLandscape = screenWidth > screenHeight
 
             // Center content on wider screens
             Box(
@@ -451,8 +453,16 @@ fun GradeSelectionUi(
                             )
 
                         // Use LazyVerticalGrid for adaptive layout
+                        // In landscape mode, limit to 2 columns to prevent text overflow
+                        val gridColumns =
+                            if (isLandscape) {
+                                GridCells.Fixed(2)
+                            } else {
+                                GridCells.Adaptive(minSize = MIN_GRADE_CARD_WIDTH)
+                            }
+
                         LazyVerticalGrid(
-                            columns = GridCells.Adaptive(minSize = MIN_GRADE_CARD_WIDTH),
+                            columns = gridColumns,
                             modifier =
                                 Modifier
                                     .fillMaxWidth()

--- a/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/onboarding/GradeSelectionScreen.kt
@@ -465,7 +465,7 @@ fun GradeSelectionUi(
                         // Calculate grid height based on number of rows needed
                         // LazyVerticalGrid requires height constraint when inside scrollable parent
                         val numRows = (state.availableGrades.size + numColumns - 1) / numColumns // Ceiling division
-                        val cardHeight = 150.dp
+                        val cardHeight = 158.dp // 150dp card + 8dp vertical padding (4dp top + 4dp bottom)
                         val verticalSpacing = 16.dp
                         val gridHeight = (cardHeight * numRows) + (verticalSpacing * (numRows - 1).coerceAtLeast(0))
 
@@ -516,6 +516,7 @@ private fun GradeCard(
         modifier =
             modifier
                 .fillMaxWidth()
+                .padding(vertical = 4.dp)
                 .height(150.dp),
         border =
             if (isSelected) {


### PR DESCRIPTION
## Summary
Fixes multiple adaptive layout issues in the grade selection screen, particularly in landscape mode.

## Changes Made

### Layout Fixes
- **Landscape Mode**: Limited grade cards to 2 columns to prevent text overflow
- **Height Calculation**: Fixed LazyVerticalGrid height to match actual rows needed (prevents empty space)
- **Shadow Clipping**: Added vertical padding to cards to prevent shadow cut-off

### Code Improvements
- **Constants**: Extracted card dimensions to constants for better maintainability
  - `GRADE_CARD_HEIGHT = 150.dp`
  - `GRADE_CARD_VERTICAL_PADDING = 8.dp`
- **Deduplication**: Removed duplicate column count logic
- **Spacing**: Adjusted vertical spacing (4dp between cards) for tighter, cleaner layout
- **Consistency**: LazyVerticalGrid now uses `verticalSpacing` variable instead of hardcoded values

## Visual Improvements
- Portrait mode: Cards display correctly with proper spacing
- Landscape mode: 2-column grid prevents text overflow and utilizes space efficiently
- Card shadows: Fully visible without clipping
- Layout: No excessive empty space below grade cards

## Testing
- ✅ Pre-commit checks passed (formatKotlin, lintKotlin, tests, builds)
- ✅ Verified in both portrait and landscape orientations

## Related Issues
Resolves layout issues discovered during adaptive layout refactoring.