### PR TITLE
fix(home): Improve Quick Stats card layout on phone devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Users can still enable adaptive difficulty in Parent Settings
   - Existing users unaffected (setting preserved in DataStore)
 
+### Fixed
+- **Home Screen Quick Stats Layout**: Fixed stats card layout on phone devices
+  - Changed from 1-column stacked layout to 2-column side-by-side layout
+  - "Problems Solved" and "Accuracy" now display horizontally on phones
+  - Increased height from 90dp to 120dp to prevent content cutoff
+  - Expanded screens (>840dp) continue to show 3 columns with Sessions count
+
 ## [1.23.0] - 2026-01-03
 
 ### Added

--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeUi.kt
@@ -542,6 +542,80 @@ private fun StatItem(
 }
 
 /**
+ * Preview for QuickStatsCard with 2 columns (compact/phone layout)
+ */
+@Preview(showBackground = true, widthDp = 400, name = "Stats Card - 2 Columns (Phone)")
+@Composable
+private fun QuickStatsCardTwoColumnPreview() {
+    KidsMathTutorAppTheme {
+        QuickStatsCard(
+            stats =
+                SessionStats(
+                    totalProblems = 150,
+                    correctCount = 135,
+                    accuracy = 90f,
+                    sessionCount = 15,
+                ),
+            screenWidth = 400.dp,
+        )
+    }
+}
+
+/**
+ * Preview for QuickStatsCard with 3 columns (expanded/tablet layout)
+ */
+@Preview(showBackground = true, widthDp = 900, name = "Stats Card - 3 Columns (Tablet)")
+@Composable
+private fun QuickStatsCardThreeColumnPreview() {
+    KidsMathTutorAppTheme {
+        QuickStatsCard(
+            stats =
+                SessionStats(
+                    totalProblems = 250,
+                    correctCount = 230,
+                    accuracy = 92f,
+                    sessionCount = 25,
+                ),
+            screenWidth = 900.dp,
+        )
+    }
+}
+
+/**
+ * Preview for QuickStatsCard with no data
+ */
+@Preview(showBackground = true, widthDp = 400, name = "Stats Card - No Data")
+@Composable
+private fun QuickStatsCardNoDataPreview() {
+    KidsMathTutorAppTheme {
+        QuickStatsCard(
+            stats = SessionStats.EMPTY,
+            screenWidth = 400.dp,
+        )
+    }
+}
+
+/**
+ * Preview for QuickStatsCard in dark theme
+ */
+@Preview(showBackground = true, widthDp = 400, name = "Stats Card - Dark Theme")
+@Composable
+private fun QuickStatsCardDarkPreview() {
+    KidsMathTutorAppTheme(darkTheme = true) {
+        QuickStatsCard(
+            stats =
+                SessionStats(
+                    totalProblems = 100,
+                    correctCount = 85,
+                    accuracy = 85f,
+                    sessionCount = 10,
+                ),
+            screenWidth = 400.dp,
+        )
+    }
+}
+
+/**
  * Latest badges section showing recently unlocked badges.
  * Uses adaptive grid: 3 per row (compact), 5 per row (medium), 6 per row (expanded).
  */

--- a/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/home/HomeUi.kt
@@ -65,8 +65,8 @@ import java.time.LocalDate
 import dev.hossain.mathtutor.ui.component.BadgeIcon as BadgeIconImage
 
 // Heights for adaptive grids
-private val STATS_GRID_HEIGHT_COMPACT: Dp = 180.dp // Single column needs more vertical space
-private val STATS_GRID_HEIGHT_MULTI_COLUMN: Dp = 90.dp // Multi-column layout is more compact
+private val STATS_GRID_HEIGHT_TWO_COLUMN: Dp = 120.dp // 2 columns (phones/tablets)
+private val STATS_GRID_HEIGHT_THREE_COLUMN: Dp = 90.dp // 3 columns (expanded screens)
 private val BADGES_GRID_HEIGHT: Dp = 120.dp
 
 /**
@@ -454,11 +454,8 @@ private fun QuickStatsCard(
                     when {
                         screenWidth >= EXPANDED_WIDTH_BREAKPOINT -> 3
 
-                        // expanded: 3 columns
-                        screenWidth >= MEDIUM_WIDTH_BREAKPOINT -> 2
-
-                        // medium: 2 columns
-                        else -> 1 // compact: 1 column
+                        // expanded: 3 columns (shows Sessions count)
+                        else -> 2 // compact & medium: 2 columns (Problems + Accuracy)
                     }
 
                 // Show stats in adaptive grid
@@ -470,10 +467,10 @@ private fun QuickStatsCard(
                         Modifier
                             .fillMaxWidth()
                             .height(
-                                if (columns == 1) {
-                                    STATS_GRID_HEIGHT_COMPACT
+                                if (columns == 3) {
+                                    STATS_GRID_HEIGHT_THREE_COLUMN
                                 } else {
-                                    STATS_GRID_HEIGHT_MULTI_COLUMN
+                                    STATS_GRID_HEIGHT_TWO_COLUMN
                                 },
                             ),
                 ) {


### PR DESCRIPTION
## Problem
The Quick Stats card on the Home screen was displaying stats in a single column on phone devices, wasting available horizontal space and causing content to appear stacked vertically.

## Solution
- Changed layout from 1-column to 2-column for phones and tablets
- 'Problems Solved' and 'Accuracy' now display side-by-side
- Increased grid height from 90dp to 120dp to prevent content cutoff
- Expanded screens (>840dp) continue to show 3 columns with Sessions count

## Testing
- ✅ Tested on phone devices (< 600dp width)
- ✅ Tested on tablet devices (600-840dp width)
- ✅ Tested on expanded screens (> 840dp width)
- ✅ Content no longer gets cut off

## Changes
- Updated `HomeUi.kt` QuickStatsCard grid layout logic
- Updated height constants for better content display
- Updated CHANGELOG.md with fix details