### PR TITLE
fix: Close text hint dialog when showing visual hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Visual Hint Dialog Transition**: Fixed issue where text hint dialog wasn't dismissed when showing visual hint
+  - Text hint now properly closes when "Show Visually" button is pressed
+  - Only the visual hint dialog is displayed, improving user experience
+
 ## [1.24.0] - 2026-01-04
 
 ### Added

--- a/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/mathpractice/MathPracticePresenter.kt
@@ -717,6 +717,8 @@ class MathPracticePresenter
                     }
 
                     is MathPracticeScreen.Event.ShowVisualHint -> {
+                        // Close the text hint dialog by clearing the hint text
+                        currentHintText = null
                         showVisualHint = true
 
                         // Analytics: Track visual hint usage


### PR DESCRIPTION
## Description
Fixes an issue where the text hint dialog wasn't dismissed when showing the visual hint, causing both dialogs to display simultaneously.

## Problem
When a child pressed the "Show Visually" button in the text hint dialog, the visual hint dialog would open but the text hint dialog would remain visible. This violates Material Design principles for dialog transitions and causes UI clutter.

## Solution
Modified the `ShowVisualHint` event handler in `MathPracticePresenter.kt` to clear `currentHintText` when displaying the visual hint. This ensures only one dialog is visible at a time.

## Changes
- **MathPracticePresenter.kt**: Added `currentHintText = null` to the `ShowVisualHint` event handler
- **CHANGELOG.md**: Documented the fix under [Unreleased] section

## Testing
- ✅ All pre-commit checks passed (formatting, linting, tests, builds)
- ✅ Code follows Material Design best practices for dialog transitions
- ✅ Only one hint dialog displays at a time

## Related Issues
N/A

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)