### PR TITLE
[UPDATE] All libs to latest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,7 +146,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     // AndroidX Browser (Custom Tabs) for opening external links
-    implementation("androidx.browser:browser:1.9.0")
+    implementation(libs.androidx.browser)
 
     // Room Database
     implementation(libs.androidx.room.runtime)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ activityCompose = "1.13.0"
 # https://developer.android.com/build/releases/gradle-plugin
 agp = "8.13.2"
 circuit = "0.33.1"
-composeBom = "2026.05.00"
+composeBom = "2026.05.01"
 coreKtx = "1.18.0"
 espressoCore = "3.7.0"
 # Firebase BoM (Bill of Materials) - manages all Firebase library versions
@@ -15,9 +15,11 @@ firebaseCrashlytics = "3.0.7"
 # Google Services plugin for processing google-services.json
 # https://developers.google.com/android/guides/google-services-plugin
 googleServices = "4.4.4"
-googleFonts = "1.10.0"
+googleFonts = "1.11.2"
 junit = "4.13.2"
 junitVersion = "1.3.0"
+
+browserVersion = "1.10.0"
 
 # https://kotlinlang.org/docs/releases.html
 kotlin = "2.3.21"
@@ -35,12 +37,12 @@ metro = "1.1.1"
 # Timber - A logger with a small, extensible API which provides utility on top of Android's normal Log class
 # https://github.com/JakeWharton/timber
 timber = "5.0.1"
-androidxWork = "2.11.0"
-datastorePreferences = "1.2.0"
+androidxWork = "2.11.2"
+datastorePreferences = "1.2.1"
 # Room Database - https://developer.android.com/jetpack/androidx/releases/room
 room = "2.8.4"
 # Kotlin Coroutines - https://github.com/Kotlin/kotlinx.coroutines
-coroutines = "1.10.2"
+coroutines = "1.11.0"
 # Robolectric for Android unit tests - https://robolectric.org/
 robolectric = "4.16.1"
 # Media3 ExoPlayer - https://developer.android.com/media/media3
@@ -136,6 +138,8 @@ androidx-test-core = { group = "androidx.test", name = "core", version = "1.7.0"
 # Media3 ExoPlayer - https://developer.android.com/media/media3
 androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
 androidx-media3-common = { group = "androidx.media3", name = "media3-common", version.ref = "media3" }
+
+androidx-browser = {group = "androidx.browser", name="browser", version.ref = "browserVersion"}
 
 # Google Truth - Fluent testing library
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }


### PR DESCRIPTION
This pull request updates several library dependencies to their latest versions and improves dependency management by switching to version catalogs for some libraries. The main changes include updating the AndroidX Browser, Google Fonts, and several other libraries, as well as refactoring how the AndroidX Browser dependency is referenced.

**Dependency version updates:**

* Updated `composeBom` to `2026.05.01`, `googleFonts` to `1.11.2`, `androidxWork` to `2.11.2`, `datastorePreferences` to `1.2.1`, and `coroutines` to `1.11.0` in `gradle/libs.versions.toml`. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL6-R6) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL18-R23) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL38-R45)

**Dependency management improvements:**

* Introduced a new `browserVersion` variable and added an `androidx-browser` entry in the version catalog (`gradle/libs.versions.toml`) for consistent version management. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL18-R23) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR142-R143)
* Refactored the `app/build.gradle.kts` file to use the version catalog reference `libs.androidx.browser` instead of a hardcoded version for the AndroidX Browser dependency.