### PR TITLE
fixed some build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improves IDE project identification and visual consistency
 
 ### Fixed
-- **Test Accuracy**: Corrected inaccurate test assertions in `GradeAwareProblemGeneratorTest` where Kindergarten number ranges were documented and tested as `1-10` instead of the actual `1-9`, addition results as `2-18` instead of `2-10`, and subtraction results as `0-9` instead of `0-8`
+- **Compiler Warnings**: Resolved four Kotlin compiler warnings in the codebase
+  - `FirebaseAnalyticsService`: Added `@param:` target to `@ApplicationContext` annotation to suppress future annotation target ambiguity warning (KT-73255)
+  - `SessionSeeder`: Moved `@Inject` annotation from constructor to class level as recommended when there is only one inject-annotated constructor
+  - `AppGraph`/`ComposeAppComponentFactory`: Replaced deprecated `Provider<T>` type with the idiomatic `() -> T` function syntax form as recommended by Metro
+  - `SettingsUi`: Replaced deprecated `setToolbarColor()` with `CustomTabColorSchemeParams` and `setColorSchemeParams()` for Custom Tabs toolbar theming
 - **Test Comments**: Updated misleading comment in `Phase3EdgeCasesTest` that claimed to "verify all 15 requirements are unique types" when the assertion only checks the count
 - **Test Stubs**: Replaced `TODO("Not needed for tests")` placeholders in `FakeCustomChallengeService` with `UnsupportedOperationException` to give a clear, actionable error if accidentally called
 

--- a/app/src/main/java/dev/hossain/mathtutor/analytics/FirebaseAnalyticsService.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/analytics/FirebaseAnalyticsService.kt
@@ -34,7 +34,7 @@ import timber.log.Timber
 @Inject
 class FirebaseAnalyticsService
     constructor(
-        @ApplicationContext private val context: Context,
+        @param:ApplicationContext private val context: Context,
         private val userPreferencesRepository: UserPreferencesRepository,
     ) : AnalyticsService {
         private val firebaseAnalytics: FirebaseAnalytics by lazy {

--- a/app/src/main/java/dev/hossain/mathtutor/devtools/SessionSeeder.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/devtools/SessionSeeder.kt
@@ -33,8 +33,8 @@ interface SessionSeeder {
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
+@Inject
 class SessionSeederImpl
-    @Inject
     constructor(
         private val problemGenerator: ProblemGenerator,
         private val sessionRepository: SessionRepository,

--- a/app/src/main/java/dev/hossain/mathtutor/di/AppGraph.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/di/AppGraph.kt
@@ -8,7 +8,6 @@ import dev.hossain.mathtutor.domain.repository.BadgeRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Multibinds
-import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 import kotlin.reflect.KClass
@@ -43,7 +42,7 @@ interface AppGraph {
      * See https://zacsweers.github.io/metro/latest/bindings/#multibindings
      */
     @Multibinds
-    val activityProviders: Map<KClass<out Activity>, Provider<Activity>>
+    val activityProviders: Map<KClass<out Activity>, () -> Activity>
 
     /**
      * Circuit instance for handling UI presentation and state management.

--- a/app/src/main/java/dev/hossain/mathtutor/di/ComposeAppComponentFactory.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/di/ComposeAppComponentFactory.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import androidx.annotation.Keep
 import androidx.core.app.AppComponentFactory
 import dev.hossain.mathtutor.KidsMathTutorApp
-import dev.zacsweers.metro.Provider
 import kotlin.reflect.KClass
 
 /**
@@ -57,7 +56,7 @@ class ComposeAppComponentFactory : AppComponentFactory() {
     private inline fun <reified T : Any> getInstance(
         classLoader: ClassLoader,
         className: String,
-        providers: Map<KClass<out T>, Provider<T>>,
+        providers: Map<KClass<out T>, () -> T>,
     ): T? {
         // Load the class using the provided ClassLoader and attempt to retrieve the instance.
         val clazz = Class.forName(className, false, classLoader).asSubclass(T::class.java)
@@ -111,6 +110,6 @@ class ComposeAppComponentFactory : AppComponentFactory() {
      * This map is initialized when the application is created via the Metro dependency graph.
      */
     companion object {
-        private lateinit var activityProviders: Map<KClass<out Activity>, Provider<Activity>>
+        private lateinit var activityProviders: Map<KClass<out Activity>, () -> Activity>
     }
 }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/importchallenge/ImportChallengeUi.kt
@@ -866,10 +866,10 @@ private fun QuickStartStep(
                     Icon(
                         imageVector = Icons.Outlined.OpenInBrowser,
                         contentDescription = null,
-                        modifier = Modifier.size(16.dp),
+                        modifier = Modifier.size(18.dp),
                     )
                     Spacer(modifier = Modifier.width(4.dp))
-                    Text(buttonLabel, style = MaterialTheme.typography.labelSmall)
+                    Text(buttonLabel, style = MaterialTheme.typography.labelLarge)
                 }
             }
         }

--- a/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/dev/hossain/mathtutor/ui/settings/SettingsUi.kt
@@ -3,6 +3,7 @@ package dev.hossain.mathtutor.ui.settings
 import android.content.Context
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -509,7 +510,11 @@ private fun openExternalUrl(
     try {
         val uri = url.toUri()
         val builder = CustomTabsIntent.Builder().setShowTitle(true)
-        toolbarColor?.let { builder.setToolbarColor(it) }
+        toolbarColor?.let {
+            val colorSchemeParams = CustomTabColorSchemeParams.Builder().setToolbarColor(it).build()
+            builder.setColorSchemeParams(CustomTabsIntent.COLOR_SCHEME_LIGHT, colorSchemeParams)
+            builder.setColorSchemeParams(CustomTabsIntent.COLOR_SCHEME_DARK, colorSchemeParams)
+        }
         val customTabsIntent = builder.build()
 
         customTabsIntent.launchUrl(context, uri)


### PR DESCRIPTION
This pull request primarily resolves several Kotlin compiler warnings by updating annotations, replacing deprecated APIs, and improving code idioms throughout the codebase. It also makes minor UI adjustments for consistency. The most important changes are grouped below:

**Compiler Warnings and Dependency Injection Improvements:**

* Added the `@param:` target to the `@ApplicationContext` annotation in `FirebaseAnalyticsService` to prevent annotation target ambiguity warnings.
* Moved the `@Inject` annotation from the constructor to the class level in `SessionSeederImpl`, following best practices for classes with a single inject-annotated constructor.
* Replaced the deprecated `Provider<T>` type with the idiomatic `() -> T` function syntax in both `AppGraph` and `ComposeAppComponentFactory`, as recommended by the Metro library. [[1]](diffhunk://#diff-38141a59858ce0f35792117219e87c26f84cf78fa80ece3e16440529f6e93eefL11) [[2]](diffhunk://#diff-38141a59858ce0f35792117219e87c26f84cf78fa80ece3e16440529f6e93eefL46-R45) [[3]](diffhunk://#diff-c8ad993ed6ae4f9707b30c588e13dc7faac7ff8a0e44310b7fcf450938b549b7L9) [[4]](diffhunk://#diff-c8ad993ed6ae4f9707b30c588e13dc7faac7ff8a0e44310b7fcf450938b549b7L60-R59) [[5]](diffhunk://#diff-c8ad993ed6ae4f9707b30c588e13dc7faac7ff8a0e44310b7fcf450938b549b7L114-R113)

**UI and Theming Updates:**

* Updated `SettingsUi` to replace the deprecated `setToolbarColor()` method with `CustomTabColorSchemeParams` and `setColorSchemeParams()` for theming Custom Tabs, ensuring compatibility with newer APIs. [[1]](diffhunk://#diff-f44158a416f1fec1eb634c111426a9c93294e3896036e3b7b838836d49eea4c0R6) [[2]](diffhunk://#diff-f44158a416f1fec1eb634c111426a9c93294e3896036e3b7b838836d49eea4c0L512-R517)
* Adjusted icon and text sizes in `ImportChallengeUi` for improved visual consistency.

(References: [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL17-R21) [[2]](diffhunk://#diff-70cc8f56f3b1a0edb841421b4951194d93085bfa067d993cd0eb8bf31f887560L37-R37) [[3]](diffhunk://#diff-1f4503dc2172e1908ddb60b3e6ec883ccf136b45a09a14ca0e0c3f5d6f7ca84bL36-R37) [[4]](diffhunk://#diff-38141a59858ce0f35792117219e87c26f84cf78fa80ece3e16440529f6e93eefL11) [[5]](diffhunk://#diff-38141a59858ce0f35792117219e87c26f84cf78fa80ece3e16440529f6e93eefL46-R45) [[6]](diffhunk://#diff-c8ad993ed6ae4f9707b30c588e13dc7faac7ff8a0e44310b7fcf450938b549b7L9) [[7]](diffhunk://#diff-c8ad993ed6ae4f9707b30c588e13dc7faac7ff8a0e44310b7fcf450938b549b7L60-R59) [[8]](diffhunk://#diff-c8ad993ed6ae4f9707b30c588e13dc7faac7ff8a0e44310b7fcf450938b549b7L114-R113) [[9]](diffhunk://#diff-f44158a416f1fec1eb634c111426a9c93294e3896036e3b7b838836d49eea4c0R6) [[10]](diffhunk://#diff-f44158a416f1fec1eb634c111426a9c93294e3896036e3b7b838836d49eea4c0L512-R517) [[11]](diffhunk://#diff-df5a3a821fd8200e15f56484c546c2ead4830a55db3bb71039d13bfc2f6a4615L869-R872)