### PR TITLE
[codex] Fix release docs and add AGENTS symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -164,7 +164,7 @@ Add these three secrets (one at a time):
 ### 6.1 Create a Test Release
 
 1. Go to: `https://github.com/[YOUR-USERNAME]/[YOUR-REPO]/releases/new`
-2. Create a new tag (e.g., `v1.0.0-test`)
+2. Create a new tag (e.g., `1.0.0-test`)
 3. Add a release title and description
 4. Click "Publish release"
 
@@ -178,7 +178,7 @@ Add these three secrets (one at a time):
 ### 6.3 Clean Up Test Release (Optional)
 
 - [ ] Delete the test release if desired
-- [ ] Delete the test tag: `git push --delete origin v1.0.0-test`
+- [ ] Delete the test tag: `git push --delete origin 1.0.0-test`
 
 ## Ongoing Usage
 
@@ -186,7 +186,6 @@ Add these three secrets (one at a time):
 
 The `android-release.yml` workflow automatically runs on:
 
-- **Every push to main branch**: Creates a snapshot build (artifact available for 30 days)
 - **Manual trigger**: Run the workflow manually from the Actions tab
 - **GitHub release**: Publishes APK and AAB and attaches them to the release
 
@@ -197,8 +196,8 @@ The `android-release.yml` workflow automatically runs on:
    versionCode = 2  // Increment
    versionName = "1.1.0"  // Update
    ```
-2. Commit and push to main branch
-3. Create a GitHub release with tag matching the version (e.g., `v1.1.0`)
+2. Commit and push the change through the normal pull request flow, then merge to `main`
+3. Create a GitHub release with tag matching the version (e.g., `1.1.0`)
 4. The workflow automatically builds and attaches the signed APK and AAB
 
 ### Troubleshooting


### PR DESCRIPTION
## Summary
- update `RELEASE.md` to use the repo's actual tag convention without a `v` prefix
- remove the stale claim that release artifacts are built on every push to `main`
- add a root `AGENTS.md` symlink pointing to `.github/copilot-instructions.md`

## Why
The repository currently uses plain version tags such as `1.25.0`, but `RELEASE.md` still showed `v`-prefixed examples and an outdated workflow trigger description. Adding `AGENTS.md` makes the root-level agent instructions discoverable while keeping `.github/copilot-instructions.md` as the single source of truth.

## Validation
- verified the `AGENTS.md` symlink resolves to `.github/copilot-instructions.md`
- reviewed the updated `RELEASE.md` diff against the current GitHub Actions workflow
