### PR TITLE
Release 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-06-15
+
 ### Changed
 - **AGP 9 Built-in Kotlin Migration**: Removed `org.jetbrains.kotlin.android` plugin now that AGP 9.0 provides built-in Kotlin support, and updated related build tooling
   - Upgraded Android Gradle Plugin (AGP) to `9.2.1`
@@ -2546,8 +2548,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied proper system bars insets for edge-to-edge display on onboarding screen
 - Fixed onboarding navigation to properly navigate to MathPracticeScreen after completion
 
-[unreleased]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.25.0...HEAD
-[1.25.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.24.1...1.25.0
+[unreleased]: https://github.com/hossain-khan/kids-math-tutor/compare/1.26.0...HEAD
+[1.26.0]: https://github.com/hossain-khan/kids-math-tutor/compare/1.25.0...1.26.0
+[1.25.0]: https://github.com/hossain-khan/kids-math-tutor/compare/1.24.1...1.25.0
 [1.24.1]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.24.0...1.24.1
 [1.24.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.23.0...1.24.0
 [1.23.0]: https://github.com/hossain-khan/kids-math-pup-tutor/compare/1.22.1...1.23.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "dev.hossain.mathtutor"
         minSdk = 28
         targetSdk = 36
-        versionCode = 30
-        versionName = "1.25.0"
+        versionCode = 31
+        versionName = "1.26.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Summary
- bump app version from `1.25.0` to `1.26.0`
- increment `versionCode` from `30` to `31`
- move the current `[Unreleased]` changelog entry into the dated `1.26.0` release section
- update the active changelog comparison links for the new release cut

## Changelog highlights
- AGP 9 built-in Kotlin migration
- Android Gradle Plugin updated to `9.2.1`
- Gradle wrapper updated to `9.4.1`
- removed legacy `kotlin-android` plugin wiring now that AGP 9 provides built-in Kotlin support

## Validation
- `./gradlew help`
- `./gradlew build --dry-run`
